### PR TITLE
銃弾を任意の方向に移動させる

### DIFF
--- a/Assets/Scripts/Bullet/BulletGenerator.cs
+++ b/Assets/Scripts/Bullet/BulletGenerator.cs
@@ -16,9 +16,15 @@ namespace Bullet
             // 銃弾の移動ベクトル
             Vector2 motionVector = new Vector2(-1.0f, 0.0f);
             // 銃弾を作るインターバル
-            const float createInterval = 1.0f;
+            var createInterval = 1.0f;
             // coroutineの開始
             IEnumerator coroutine = CreateBullet(position, motionVector, createInterval);
+            StartCoroutine(coroutine);
+
+            position = new Vector2(-2.0f, -2.0f);
+            motionVector = new Vector2(1.0f, 1.0f);
+            createInterval = 1.0f;
+            coroutine = CreateBullet(position, motionVector, createInterval);
             StartCoroutine(coroutine);
         }
 

--- a/Assets/Scripts/Bullet/CartridgeController.cs
+++ b/Assets/Scripts/Bullet/CartridgeController.cs
@@ -37,15 +37,17 @@ namespace Bullet
         public virtual void Initialize(Vector2 motionVector)
         {
             this.motionVector = motionVector;
+            // Calculate rotation angle
             var angle = Vector2.Dot(motionVector, Vector2.left) / motionVector.magnitude;
             angle = (float) (Mathf.Acos(angle) * 180 / Math.PI);
             angle *= (-1)*Mathf.Sign(motionVector.y);
 
+            // Check if a bullet should be flipped vertically
             if (motionVector.x > 0)
             {
-                var temp = transform.localScale;
-                temp.y *= (-1);
-                transform.localScale = temp;
+                var tempLocalScale = transform.localScale;
+                tempLocalScale.y *= (-1);
+                transform.localScale = tempLocalScale;
             }
 
             transform.Rotate(new Vector3(0, 0, angle), Space.World);

--- a/Assets/Scripts/Bullet/CartridgeController.cs
+++ b/Assets/Scripts/Bullet/CartridgeController.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using System;
+using UnityEngine;
 
 namespace Bullet
 {
@@ -29,13 +30,25 @@ namespace Bullet
 
         protected override void FixedUpdate()
         {
-            transform.Translate(motionVector * speed);
+            transform.Translate(motionVector * speed, Space.World);
         }
 
         // コンストラクタがわりのメソッド
         public virtual void Initialize(Vector2 motionVector)
         {
             this.motionVector = motionVector;
+            var angle = Vector2.Dot(motionVector, Vector2.left) / motionVector.magnitude;
+            angle = (float) (Mathf.Acos(angle) * 180 / Math.PI);
+            angle *= (-1)*Mathf.Sign(motionVector.y);
+
+            if (motionVector.x > 0)
+            {
+                var temp = transform.localScale;
+                temp.y *= (-1);
+                transform.localScale = temp;
+            }
+
+            transform.Rotate(new Vector3(0, 0, angle), Space.World);
         }
     }
 }

--- a/Assets/Scripts/Bullet/NormalBulletController.cs
+++ b/Assets/Scripts/Bullet/NormalBulletController.cs
@@ -26,7 +26,7 @@ namespace Bullet
             this.speed = 0.1f;
             width = (float) (WindowSize.WIDTH * 0.15);
             height = width;
-            this.transform.localScale = new Vector2(width, height);
+            this.transform.localScale *= new Vector2(width, height);
         }
     }
 }


### PR DESCRIPTION
https://app.mmth.pro/projects/18382/tasks#/show/158812

銃弾をワールド座標系で回転させた。
銃弾の座標系の向きが変化することに伴い、銃弾の移動もワールド座標系で移動させた。

銃弾画像（仮）には上下が存在し、左向きがデフォルトの画像なので、
右に移動させる場合には、銃弾の上下を反転させてから回転を施している。

銃弾の大きさは、画面サイズに応じた値を入力していたが、銃弾の向きを反映させるように変更。