### PR TITLE
銃弾，警告表示周りのバグ修正

### DIFF
--- a/Assets/Scripts/Bullet/BulletGenerator.cs
+++ b/Assets/Scripts/Bullet/BulletGenerator.cs
@@ -64,7 +64,7 @@ namespace Bullet
                 warning.GetComponent<Renderer>().sortingLayerName = "Warning";
                 NormalBulletWarningController warningScript = warning.GetComponent<NormalBulletWarningController>();
                 warningScript.Initialize(bullet.transform.position, bulletScript.motionVector,
-                    bulletScript.localScale);
+                    bulletScript.localScale, bulletScript.originalWidth, bulletScript.originalHeight);
 
                 // delete the bullet warning
                 warningScript.deleteWarning(bullet);

--- a/Assets/Scripts/Bullet/CartridgeController.cs
+++ b/Assets/Scripts/Bullet/CartridgeController.cs
@@ -8,15 +8,18 @@ namespace Bullet
     {
         public float localScale;
         public Vector2 motionVector;
-        protected float speed;
+        public float speed;
+        public float originalWidth;
+        public float originalHeight;
+
 
         protected override void Update()
         {
             // Check if bullet goes out of window
-            if (transform.position.x < -(WindowSize.WIDTH + localScale) / 2 ||
-                transform.position.x > (WindowSize.WIDTH + localScale) / 2 ||
-                transform.position.y < -(WindowSize.HEIGHT + localScale) / 2 ||
-                transform.position.y > (WindowSize.HEIGHT + localScale) / 2)
+            if (transform.position.x < -(WindowSize.WIDTH + localScale * originalWidth) / 2 - 0.00001f ||
+                transform.position.x > (WindowSize.WIDTH + localScale * originalWidth) / 2 + 0.00001f ||
+                transform.position.y < -(WindowSize.HEIGHT + localScale * originalHeight) / 2 - 0.00001f ||
+                transform.position.y > (WindowSize.HEIGHT + localScale * originalHeight) / 2 + 0.00001f)
                 Destroy(gameObject);
         }
 

--- a/Assets/Scripts/Bullet/CartridgeController.cs
+++ b/Assets/Scripts/Bullet/CartridgeController.cs
@@ -9,6 +9,8 @@ namespace Bullet
         public float localScale;
         public Vector2 motionVector;
         public float speed;
+
+        // 元画像のサイズ
         public float originalWidth;
         public float originalHeight;
 

--- a/Assets/Scripts/Bullet/CartridgeController.cs
+++ b/Assets/Scripts/Bullet/CartridgeController.cs
@@ -6,6 +6,7 @@ namespace Bullet
 {
     public abstract class CartridgeController : BulletController
     {
+        public float additionalMargin = 0.00001f;
         public float localScale;
         public Vector2 motionVector;
         public float speed;
@@ -18,10 +19,10 @@ namespace Bullet
         protected override void Update()
         {
             // Check if bullet goes out of window
-            if (transform.position.x < -(WindowSize.WIDTH + localScale * originalWidth) / 2 - 0.00001f ||
-                transform.position.x > (WindowSize.WIDTH + localScale * originalWidth) / 2 + 0.00001f ||
-                transform.position.y < -(WindowSize.HEIGHT + localScale * originalHeight) / 2 - 0.00001f ||
-                transform.position.y > (WindowSize.HEIGHT + localScale * originalHeight) / 2 + 0.00001f)
+            if (transform.position.x < -((WindowSize.WIDTH + localScale * originalWidth) / 2 + additionalMargin) ||
+                transform.position.x > (WindowSize.WIDTH + localScale * originalWidth) / 2 + additionalMargin ||
+                transform.position.y < -((WindowSize.HEIGHT + localScale * originalHeight) / 2 + additionalMargin) ||
+                transform.position.y > (WindowSize.HEIGHT + localScale * originalHeight) / 2 + additionalMargin)
                 Destroy(gameObject);
         }
 

--- a/Assets/Scripts/Bullet/NormalBulletController.cs
+++ b/Assets/Scripts/Bullet/NormalBulletController.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using UnityEditor;
+using UnityEngine;
 
 namespace Bullet
 {
@@ -9,9 +10,10 @@ namespace Bullet
         {
             Initialize(motionVector);
             speed = 0.1f;
-            originalWidth = 1.5f;
-            originalHeight = 0.5f;
+            originalWidth = GetComponent<Renderer>().bounds.size.x;
+            originalHeight = GetComponent<Renderer>().bounds.size.y;
             localScale = (float) (WindowSize.WIDTH * 0.15);
+
             if (motionVector.Equals(Vector2.right))
                 transform.position = new Vector2((float) (-(WindowSize.WIDTH + localScale * originalWidth) / 2),
                     position.y);

--- a/Assets/Scripts/Bullet/NormalBulletController.cs
+++ b/Assets/Scripts/Bullet/NormalBulletController.cs
@@ -9,17 +9,19 @@ namespace Bullet
         {
             Initialize(motionVector);
             speed = 0.1f;
+            originalWidth = 1.5f;
+            originalHeight = 0.5f;
             localScale = (float) (WindowSize.WIDTH * 0.15);
-
             if (motionVector.Equals(Vector2.right))
-                transform.position = new Vector2(-(WindowSize.WIDTH + localScale) / 2, position.y);
+                transform.position = new Vector2((float) (-(WindowSize.WIDTH + localScale * originalWidth) / 2),
+                    position.y);
             else if (motionVector.Equals(Vector2.left))
-                transform.position = new Vector2((WindowSize.WIDTH + localScale) / 2, position.y);
+                transform.position = new Vector2((float) ((WindowSize.WIDTH + localScale * originalWidth) / 2),
+                    position.y);
             else if (motionVector.Equals(Vector2.up))
-                transform.position = new Vector2(position.x, -(WindowSize.HEIGHT + localScale) / 2);
+                transform.position = new Vector2(position.x, -(WindowSize.HEIGHT + localScale * originalHeight) / 2);
             else if (motionVector.Equals(Vector2.down))
-                transform.position = new Vector2(position.x, (WindowSize.HEIGHT + localScale) / 2);
-
+                transform.position = new Vector2(position.x, (WindowSize.HEIGHT + localScale * originalHeight) / 2);
             // Check if a bullet should be flipped vertically
             transform.localScale *= new Vector2(localScale, -1 * Mathf.Sign(motionVector.x) * localScale);
         }

--- a/Assets/Scripts/Warning/CartridgeWarningController.cs
+++ b/Assets/Scripts/Warning/CartridgeWarningController.cs
@@ -1,7 +1,51 @@
-﻿namespace Warning
+﻿using System.Collections;
+using Bullet;
+using Directors;
+using UnityEngine;
+
+namespace Warning
 {
     public class CartridgeWarningController : WarningController
     {
         public float localScale;
+        public float originalHeight;
+        public float originalWidth;
+
+        private void OnEnable()
+        {
+            GamePlayDirector.OnSucceed += OnSucceed;
+            GamePlayDirector.OnFail += OnFail;
+        }
+
+        private void OnDisable()
+        {
+            GamePlayDirector.OnSucceed -= OnSucceed;
+            GamePlayDirector.OnFail -= OnFail;
+        }
+
+        private void OnFail()
+        {
+            Destroy(gameObject);
+        }
+
+        private void OnSucceed()
+        {
+            Destroy(gameObject);
+        }
+
+
+        public void deleteWarning(GameObject bullet)
+        {
+            var tempSpeed = bullet.GetComponent<CartridgeController>().speed;
+            bullet.GetComponent<CartridgeController>().speed = 0.0f;
+            StartCoroutine(delete(bullet, tempSpeed));
+        }
+
+        private IEnumerator delete(GameObject bullet, float speed)
+        {
+            yield return new WaitForSeconds(1.0f);
+            bullet.GetComponent<CartridgeController>().speed = speed;
+            Destroy(gameObject);
+        }
     }
 }

--- a/Assets/Scripts/Warning/CartridgeWarningController.cs
+++ b/Assets/Scripts/Warning/CartridgeWarningController.cs
@@ -38,6 +38,7 @@ namespace Warning
         public void deleteWarning(GameObject bullet)
         {
             var tempSpeed = bullet.GetComponent<CartridgeController>().speed;
+            // the bullet does not move while warning is existing
             bullet.GetComponent<CartridgeController>().speed = 0.0f;
             StartCoroutine(delete(bullet, tempSpeed));
         }

--- a/Assets/Scripts/Warning/CartridgeWarningController.cs
+++ b/Assets/Scripts/Warning/CartridgeWarningController.cs
@@ -8,6 +8,7 @@ namespace Warning
     public class CartridgeWarningController : WarningController
     {
         public float localScale;
+        // 元画像のサイズ
         public float originalHeight;
         public float originalWidth;
 

--- a/Assets/Scripts/Warning/NormalBulletWarningController.cs
+++ b/Assets/Scripts/Warning/NormalBulletWarningController.cs
@@ -4,13 +4,16 @@ namespace Warning
 {
     public class NormalBulletWarningController : CartridgeWarningController
     {
-        public override void Initialize(Vector2 bulletPosition, Vector2 bulletMotionVector, float bulletLocalScale)
+        public override void Initialize(Vector2 bulletPosition, Vector2 bulletMotionVector, float bulletLocalScale,
+            float bulletWidth, float bulletHeight)
         {
             localScale = (float) (WindowSize.WIDTH * 0.15);
+            originalWidth = 1.82f;
+            originalHeight = 1.52f;
             transform.localScale *= new Vector2(localScale, localScale);
             transform.position = bulletPosition + Vector2.Scale(bulletMotionVector,
-                                     new Vector2((bulletLocalScale + localScale) / 2,
-                                         (bulletLocalScale + localScale) / 2));
+                                     new Vector2((bulletLocalScale * bulletWidth + localScale * originalWidth) / 2,
+                                         (bulletLocalScale * bulletHeight + localScale * originalHeight) / 2));
         }
     }
 }

--- a/Assets/Scripts/Warning/NormalBulletWarningController.cs
+++ b/Assets/Scripts/Warning/NormalBulletWarningController.cs
@@ -8,8 +8,8 @@ namespace Warning
             float bulletWidth, float bulletHeight)
         {
             localScale = (float) (WindowSize.WIDTH * 0.15);
-            originalWidth = 1.82f;
-            originalHeight = 1.52f;
+            originalWidth = GetComponent<Renderer>().bounds.size.x;
+            originalHeight = GetComponent<Renderer>().bounds.size.y;
             transform.localScale *= new Vector2(localScale, localScale);
             transform.position = bulletPosition + Vector2.Scale(bulletMotionVector,
                                      new Vector2((bulletLocalScale * bulletWidth + localScale * originalWidth) / 2,

--- a/Assets/Scripts/Warning/WarningController.cs
+++ b/Assets/Scripts/Warning/WarningController.cs
@@ -1,25 +1,12 @@
-﻿using System.Collections;
-using UnityEngine;
+﻿using UnityEngine;
 
 namespace Warning
 {
     public class WarningController : MonoBehaviour
     {
-        public virtual void Initialize(Vector2 bulletPosition, Vector2 bulletMotionVector, float bulletLocalScale)
+        public virtual void Initialize(Vector2 bulletPosition, Vector2 bulletMotionVector, float bulletLocalScale,
+            float bulletWidth, float bulletHeight)
         {
-        }
-
-        public void deleteWarning(GameObject bullet)
-        {
-            bullet.SetActive(false);
-            StartCoroutine(delete(bullet));
-        }
-
-        private IEnumerator delete(GameObject bullet)
-        {
-            yield return new WaitForSeconds(1.0f);
-            bullet.SetActive(true);
-            Destroy(gameObject);
         }
     }
 }


### PR DESCRIPTION
## 対象イシュー
https://app.mmth.pro/projects/18382/tasks#/show/187792

## 概要
・銃弾の端がちょうど画面の端に一致するようにできてない．
・銃弾を表示する際にsetActiveを使わないで実装する．
・銃弾警告を，成功/失敗状態どちらに変わる場合においても消す．

## 技術的な内容
銃弾の位置xが画面外tに出ると銃弾を消去する、つまり|x|>|t|の時消去する。
しかし、初期位置x=tの時、直ちに消去されてしまう。
（おそらく、丸め誤差とかかと。。。）
今は|x|>|t+ε|(ε=0.00001)の時消去するようにしている。

## キャプチャ
