### PR TITLE
パネルの移動完了前にフリック検知をしてしまう

### DIFF
--- a/Assets/Scripts/GamePlayScene/Panel/NormalPanelController.cs
+++ b/Assets/Scripts/GamePlayScene/Panel/NormalPanelController.cs
@@ -77,6 +77,9 @@ namespace Panel
 
         private void HandleFlick(object sender, System.EventArgs e)
         {
+            // パネル移動中はフリックを無視する
+            if (moving) return;
+
             FlickGesture gesture = sender as FlickGesture;
 
             if (gesture.State != FlickGesture.GestureState.Recognized) return;


### PR DESCRIPTION
## 対象イシュー
https://app.mmth.pro/projects/18382/tasks#/show/193047

## 概要
下記の問題に対処した．
- パネルのフリック検知をした後，移動先に親タイルに移動する処理の途中でそのパネルのフリック検知が有効になっており，斜めに移動してしまう場合がある．
- 成功判定はパネルの移動が完了した際に成されるため，成功盤面を通り過ぎて成功できない場合がある．

## 技術的な内容
移動中にフリック検知がもし起きた場合には，その処理を無視する．`Update()`内で
`GetComponent<FlickGesture>().enable`
を`true`や`false`にすることも考えたが，`Update()`内の処理が増えることが嫌だったので，こちらの実装にしてみました．