### PR TITLE
1つのステージを作り上げる

### DIFF
--- a/Assets/Scripts/Data.cs
+++ b/Assets/Scripts/Data.cs
@@ -9,7 +9,7 @@
 
 public static class TileSize
 {
-    public const float WIDTH = WindowSize.WIDTH * 0.24f;
+    public const float WIDTH = WindowSize.WIDTH * 0.22f;
     public const float HEIGHT = WIDTH;
 
     // タイル群の上端位置を指定

--- a/Assets/Scripts/GamePlayScene/Bullet/BulletGenerator.cs
+++ b/Assets/Scripts/GamePlayScene/Bullet/BulletGenerator.cs
@@ -22,13 +22,13 @@ namespace Bullet
             {
                 case "1":
                     // 銃弾の初期位置
-                    Vector2 position = new Vector2(6.5f, 4.0f);
+                    Vector2 position = new Vector2(6.5f, 4.61f);
                     // 銃弾の移動ベクトル
                     Vector2 motionVector = new Vector2(-1.0f, 0.0f);
                     // 銃弾の出現時刻
                     var appearanceTiming = 1.0f;
                     // 銃弾を作るインターバル
-                    var createInterval = 1.0f;
+                    var createInterval = 2.0f;
                     // coroutineのリスト
                     coroutines.Add(CreateBullet(position, motionVector, appearanceTiming, createInterval));
                     coroutines.Add(CreateBullet(position: new Vector2(-6.5f, 6.0f),

--- a/Assets/Scripts/GamePlayScene/Bullet/NormalBulletController.cs
+++ b/Assets/Scripts/GamePlayScene/Bullet/NormalBulletController.cs
@@ -9,10 +9,10 @@ namespace Bullet
         public void Initialize(Vector2 position, Vector2 motionVector)
         {
             Initialize(motionVector);
-            speed = 0.1f;
+            speed = 0.08f;
             originalWidth = GetComponent<Renderer>().bounds.size.x;
             originalHeight = GetComponent<Renderer>().bounds.size.y;
-            localScale = (float) (WindowSize.WIDTH * 0.15);
+            localScale = (float) (WindowSize.WIDTH * 0.10);
 
             if (motionVector.Equals(Vector2.right))
                 transform.position = new Vector2((float) (-(WindowSize.WIDTH + localScale * originalWidth) / 2),

--- a/Assets/Scripts/GamePlayScene/Panel/NormalPanelController.cs
+++ b/Assets/Scripts/GamePlayScene/Panel/NormalPanelController.cs
@@ -18,7 +18,7 @@ namespace Panel
         private bool moving;
 
         // フリック時のパネルの移動速度
-        private float speed = 0.2f;
+        private float speed = 0.60f;
 
         protected override void Start()
         {

--- a/Assets/Scripts/GamePlayScene/Warning/NormalBulletWarningController.cs
+++ b/Assets/Scripts/GamePlayScene/Warning/NormalBulletWarningController.cs
@@ -7,7 +7,7 @@ namespace Warning
         public override void Initialize(Vector2 bulletPosition, Vector2 bulletMotionVector, float bulletLocalScale,
             float bulletWidth, float bulletHeight)
         {
-            localScale = (float) (WindowSize.WIDTH * 0.15);
+            localScale = (float) (WindowSize.WIDTH * 0.08);
             originalWidth = GetComponent<Renderer>().bounds.size.x;
             originalHeight = GetComponent<Renderer>().bounds.size.y;
             transform.localScale *= new Vector2(localScale, localScale);

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -6,9 +6,9 @@ EditorBuildSettings:
   serializedVersion: 2
   m_Scenes:
   - enabled: 1
-    path: Assets/Scenes/GamePlayScene.unity
-    guid: dcec7563bff464223b7c21f17f5902f5
-  - enabled: 1
     path: Assets/Scenes/StageSelectScene.unity
     guid: 4b0234159911040549a0ca37c4209712
+  - enabled: 1
+    path: Assets/Scenes/GamePlayScene.unity
+    guid: dcec7563bff464223b7c21f17f5902f5
   m_configObjects: {}

--- a/ProjectSettings/GraphicsSettings.asset
+++ b/ProjectSettings/GraphicsSettings.asset
@@ -35,6 +35,8 @@ GraphicsSettings:
   - {fileID: 15106, guid: 0000000000000000f000000000000000, type: 0}
   - {fileID: 10753, guid: 0000000000000000f000000000000000, type: 0}
   - {fileID: 10770, guid: 0000000000000000f000000000000000, type: 0}
+  - {fileID: 17000, guid: 0000000000000000f000000000000000, type: 0}
+  - {fileID: 16000, guid: 0000000000000000f000000000000000, type: 0}
   m_PreloadedShaders: []
   m_SpritesDefaultMaterial: {fileID: 10754, guid: 0000000000000000f000000000000000,
     type: 0}


### PR DESCRIPTION
## 対象イシュー


## 概要
https://app.mmth.pro/projects/18382/tasks#/show/150130
パラメータを調整し、遊べる難易度にする

## 技術的な内容
銃弾の大きさや早さ、フリック感度などを調整
タイルの横幅を画面サイズx0.24→x0.22
銃弾の出現場所・頻度を調整
Normalの銃弾の速さ0.1f->0.08f
Normalの銃弾の大きさを画面サイズx0.15->x0.10
フリックの移動速度0.2f->0.60f
Normalの警告画像の大きさを画面のサイズx0.15f->0.08f
StageSelectSceneが初期画面になるように変更

## キャプチャ

