### PR TITLE
パネルの移動を瞬間移動に戻す

### DIFF
--- a/Assets/Scripts/GamePlayScene/Bullet/CartridgeController.cs
+++ b/Assets/Scripts/GamePlayScene/Bullet/CartridgeController.cs
@@ -57,7 +57,7 @@ namespace GamePlayScene.Bullet
 				transform.position = new Vector2(position.x, (WindowSize.HEIGHT + localScale * originalHeight) / 2);
 			// Check if a bullet should be flipped vertically
 			transform.localScale *= new Vector2(localScale, -1 * Mathf.Sign(motionVector.x) * localScale);
-			
+
 			this.motionVector = motionVector;
 			// Calculate rotation angle
 			var angle = Vector2.Dot(motionVector, Vector2.left) / motionVector.magnitude;

--- a/Assets/Scripts/GamePlayScene/Panel/NormalPanelController.cs
+++ b/Assets/Scripts/GamePlayScene/Panel/NormalPanelController.cs
@@ -13,12 +13,6 @@ namespace GamePlayScene.Panel
 		// パネルが最終タイルにいるかどうかの状態
 		public bool adapted;
 
-		// パネルが移動中かどうかの状態
-		private bool moving;
-
-		// フリック時のパネルの移動速度
-		private float speed = 0.2f;
-
 		protected override void Start()
 		{
 			base.Start();
@@ -28,25 +22,6 @@ namespace GamePlayScene.Panel
 			collider.size = panelSize;
 			// 初期状態で最終タイルにいるかどうかの状態を変える
 			adapted = transform.parent.gameObject == finalTile;
-		}
-
-		protected void Update()
-		{
-			// 親タイルへの移動
-			if (transform.position != transform.parent.transform.position)
-			{
-				transform.position =
-					Vector2.MoveTowards(transform.position, transform.parent.transform.position, speed);
-				// 移動中にする
-				moving = true;
-			}
-			else
-			{
-				// 移動が完了した場合には，成功判定を行う
-				if (!moving) return;
-				gamePlayDirector.CheckClear();
-				moving = false;
-			}
 		}
 
 		public override void Initialize(GameObject finalTile)
@@ -76,9 +51,6 @@ namespace GamePlayScene.Panel
 
 		private void HandleFlick(object sender, EventArgs e)
 		{
-			// パネル移動中はフリックを無視する
-			if (moving) return;
-
 			FlickGesture gesture = sender as FlickGesture;
 
 			if (gesture.State != FlickGesture.GestureState.Recognized) return;
@@ -124,15 +96,18 @@ namespace GamePlayScene.Panel
 			if (targetTile.transform.childCount != 0) return;
 			// 親タイルの更新
 			transform.parent = targetTile.transform;
+			// 親タイルへ移動
+			transform.position = transform.parent.position;
 			// 最終タイルにいるかどうかで状態を変える
 			adapted = transform.parent.gameObject == finalTile;
+			// 成功判定
+			gamePlayDirector.CheckClear();
 		}
 
 		private void OnTriggerEnter2D(Collider2D other)
 		{
 			// 銃弾との衝突以外は考えない（現状は，パネル同士での衝突は起こりえない）
 			if (!other.gameObject.CompareTag("Bullet")) return;
-			speed = 0;
 			gameObject.GetComponent<SpriteRenderer>().color = Color.yellow;
 			// 失敗状態に移行する
 			gamePlayDirector.Dispatch(GamePlayDirector.GameState.Failure);


### PR DESCRIPTION
## 対象イシュー
https://app.mmth.pro/projects/18382/tasks#/show/195449

## 概要
タイトル通り．
パネルの移動を瞬間移動で無くしたことによる，見栄えの良さに対して，扱いづらさが増したため，元の瞬間移動の実装に戻した．

#### 瞬間移動のメリット
- 操作性の高さ（連続したパネル移動も爽快に行える）
- アルゴリズムの単純さによる，バグの出づらさ
#### デメリット
- 移動が滑らかではないため，移動している感があまりない（見方による）
- 銃弾と衝突した際に，パネルの食い込む量が気になる

## 技術的な内容
特に工夫点はない．差分を見れば理解できるはず．

## 動作確認の有無
ちゃんとした．問題はなさそう．
