### PR TITLE
タイルの個数に応じた適切な銃弾の初期配置

### DIFF
--- a/Assets/Project/Scripts/GamePlayScene/Bullet/BulletGenerator.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/BulletGenerator.cs
@@ -16,6 +16,14 @@ namespace Project.Scripts.GamePlayScene.Bullet
 		// Generatorが作成された時刻
 		public float startTime;
 
+		public enum Direction
+		{
+			ToLeft,
+			ToRight,
+			ToUp,
+			ToBottom
+		}
+
 		private enum ToLeft
 		{
 			First = 1,

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/BulletGenerator.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/BulletGenerator.cs
@@ -16,6 +16,38 @@ namespace Project.Scripts.GamePlayScene.Bullet
 		// Generatorが作成された時刻
 		public float startTime;
 
+		private enum Left
+		{
+			First = 1,
+			Second,
+			Third,
+			Fourth,
+			Fifth
+		}
+
+		private enum Right
+		{
+			First = 1,
+			Second,
+			Third,
+			Fourth,
+			Fifth
+		}
+
+		private enum Up
+		{
+			First = 1,
+			Second,
+			Third
+		}
+
+		private enum Down
+		{
+			First = 1,
+			Second,
+			Third
+		}
+
 		public void CreateBullets(int stageId)
 		{
 			List<IEnumerator> coroutines = new List<IEnumerator>();
@@ -23,24 +55,17 @@ namespace Project.Scripts.GamePlayScene.Bullet
 			switch (stageId)
 			{
 				case 1:
-					// 銃弾の初期位置
-					const int positionNumber = 1;
-					// 銃弾の移動ベクトル
-					Vector2 motionVector = new Vector2(-1.0f, 0.0f);
 					// 銃弾の出現時刻
 					const float appearanceTiming = 1.0f;
 					// 銃弾を作るインターバル
 					const float createInterval = 1.0f;
 					// coroutineのリスト
-					coroutines.Add(CreateBullet(positionNumber, motionVector, appearanceTiming, createInterval));
-					coroutines.Add(CreateBullet(positionNumber: 2,
-						motionVector: new Vector2(1.0f, 0.0f),
-						appearanceTiming: 2.0f, interval: 4.0f));
+					AddCoroutine(coroutines, Left.First, appearanceTiming, createInterval);
+					AddCoroutine(coroutine: coroutines, row: Right.Second, appearanceTiming: 2.0f,
+						createInterval: 4.0f);
 					break;
 				case 2:
-					coroutines.Add(CreateBullet(positionNumber: 5,
-						motionVector: new Vector2(1.0f, 0.0f),
-						appearanceTiming: 2.0f, interval: 4.0f));
+					AddCoroutine(coroutine: coroutines, row: Right.Fifth, appearanceTiming: 2.0f, createInterval: 4.0f);
 					break;
 				default:
 					throw new NotImplementedException();
@@ -50,13 +75,32 @@ namespace Project.Scripts.GamePlayScene.Bullet
 			foreach (IEnumerator coroutine in coroutines) StartCoroutine(coroutine);
 		}
 
+		// 銃弾の移動方向および出現させる位置を取得してCreatebullet()メソッドに引数を渡す
+		private void AddCoroutine(List<IEnumerator> coroutine, Left row, float appearanceTiming, float createInterval)
+		{
+			coroutine.Add(CreateBullet("left", (int) row, appearanceTiming, createInterval));
+		}
+
+		private void AddCoroutine(List<IEnumerator> coroutine, Right row, float appearanceTiming, float createInterval)
+		{
+			coroutine.Add(CreateBullet("right", (int) row, appearanceTiming, createInterval));
+		}
+
+		private void AddCoroutine(List<IEnumerator> coroutine, Up column, float appearanceTiming, float createInterval)
+		{
+			coroutine.Add(CreateBullet("up", (int) column, appearanceTiming, createInterval));
+		}
+
+		private void AddCoroutine(List<IEnumerator> coroutine, Down column, float appearanceTiming,
+			float createInterval)
+		{
+			coroutine.Add(CreateBullet("down", (int) column, appearanceTiming, createInterval));
+		}
+
 		// 指定した座標(x, y)に一定の時間間隔(interval)で銃弾を作成するメソッド
-		private IEnumerator CreateBullet(int positionNumber, Vector2 motionVector, float appearanceTiming,
+		private IEnumerator CreateBullet(String direction, int position, float appearanceTiming,
 			float interval)
 		{
-			// タイルの位置に合わせて銃弾の初期位置を設定する
-			Vector2 position = SetBulletPosition(positionNumber, motionVector);
-
 			var currentTime = Time.time;
 
 			// wait by the time the first bullet warning emerge
@@ -75,7 +119,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
 				bullet.GetComponent<Renderer>().sortingLayerName = "Bullet";
 				// 変数の初期設定
 				NormalCartridgeController cartridgeScript = bullet.GetComponent<NormalCartridgeController>();
-				cartridgeScript.Initialize(position, motionVector);
+				cartridgeScript.Initialize(direction, position);
 
 				// emerge a bullet warning
 				GameObject warning = Instantiate(normalBulletWarningPrefab);
@@ -92,33 +136,6 @@ namespace Project.Scripts.GamePlayScene.Bullet
 				// 一定時間(interval)待つ
 				yield return new WaitForSeconds(appearanceTiming + interval * sum - (currentTime - startTime));
 			}
-		}
-
-		// positionNumber行またはpositionNumber列目のタイルを通過するように銃弾の初期位置を指定する
-		private static Vector2 SetBulletPosition(int positionNumber, Vector2 motionVector)
-		{
-			// 銃弾が左右方向に移動する場合
-			// 入力が(1<=positionNumber<=5)行であるか調べる
-			if ((motionVector.Equals(Vector2.left) || motionVector.Equals(Vector2.right)))
-			{
-				if (positionNumber < 1 || 5 < positionNumber)
-				{
-					throw new ArgumentOutOfRangeException("positionNumber", positionNumber, null);
-				}
-			}
-			// 銃弾が上下方向に移動する場合
-			// 入力が(1<=positionNumber<=3)列であるか調べる
-			else if ((motionVector.Equals(Vector2.up) || motionVector.Equals(Vector2.down)))
-			{
-				if (positionNumber < 1 || 3 < positionNumber)
-				{
-					throw new ArgumentOutOfRangeException("positionNumber", positionNumber, null);
-				}
-			}
-
-			return new Vector2(TileSize.WIDTH * (positionNumber - 2),
-				WindowSize.HEIGHT * 0.5f - (TileSize.MARGIN_TOP + TileSize.HEIGHT * 0.5f) -
-				TileSize.HEIGHT * (positionNumber - 1));
 		}
 	}
 }

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/BulletGenerator.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/BulletGenerator.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using Project.Scripts.GamePlayScene.BulletWarning;
 using UnityEngine;
+using Project.Scripts.Library.Data;
 
 namespace Project.Scripts.GamePlayScene.Bullet
 {
@@ -23,7 +24,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
 			{
 				case 1:
 					// 銃弾の初期位置
-					Vector2 position = new Vector2(6.5f, 4.0f);
+					const int positionNumber = 1;
 					// 銃弾の移動ベクトル
 					Vector2 motionVector = new Vector2(-1.0f, 0.0f);
 					// 銃弾の出現時刻
@@ -31,13 +32,13 @@ namespace Project.Scripts.GamePlayScene.Bullet
 					// 銃弾を作るインターバル
 					const float createInterval = 1.0f;
 					// coroutineのリスト
-					coroutines.Add(CreateBullet(position, motionVector, appearanceTiming, createInterval));
-					coroutines.Add(CreateBullet(position: new Vector2(-6.5f, 6.0f),
+					coroutines.Add(CreateBullet(positionNumber, motionVector, appearanceTiming, createInterval));
+					coroutines.Add(CreateBullet(positionNumber: 2,
 						motionVector: new Vector2(1.0f, 0.0f),
 						appearanceTiming: 2.0f, interval: 4.0f));
 					break;
 				case 2:
-					coroutines.Add(CreateBullet(position: new Vector2(-6.5f, 6.0f),
+					coroutines.Add(CreateBullet(positionNumber: 5,
 						motionVector: new Vector2(1.0f, 0.0f),
 						appearanceTiming: 2.0f, interval: 4.0f));
 					break;
@@ -50,8 +51,12 @@ namespace Project.Scripts.GamePlayScene.Bullet
 		}
 
 		// 指定した座標(x, y)に一定の時間間隔(interval)で銃弾を作成するメソッド
-		private IEnumerator CreateBullet(Vector2 position, Vector2 motionVector, float appearanceTiming, float interval)
+		private IEnumerator CreateBullet(int positionNumber, Vector2 motionVector, float appearanceTiming,
+			float interval)
 		{
+			// タイルの位置に合わせて銃弾の初期位置を設定する
+			Vector2 position = SetBulletPosition(positionNumber, motionVector);
+
 			var currentTime = Time.time;
 
 			// wait by the time the first bullet warning emerge
@@ -87,6 +92,33 @@ namespace Project.Scripts.GamePlayScene.Bullet
 				// 一定時間(interval)待つ
 				yield return new WaitForSeconds(appearanceTiming + interval * sum - (currentTime - startTime));
 			}
+		}
+
+		// positionNumber行またはpositionNumber列目のタイルを通過するように銃弾の初期位置を指定する
+		private static Vector2 SetBulletPosition(int positionNumber, Vector2 motionVector)
+		{
+			// 銃弾が左右方向に移動する場合
+			// 入力が(1<=positionNumber<=5)行であるか調べる
+			if ((motionVector.Equals(Vector2.left) || motionVector.Equals(Vector2.right)))
+			{
+				if (positionNumber < 1 || 5 < positionNumber)
+				{
+					throw new ArgumentOutOfRangeException("positionNumber", positionNumber, null);
+				}
+			}
+			// 銃弾が上下方向に移動する場合
+			// 入力が(1<=positionNumber<=3)列であるか調べる
+			else if ((motionVector.Equals(Vector2.up) || motionVector.Equals(Vector2.down)))
+			{
+				if (positionNumber < 1 || 3 < positionNumber)
+				{
+					throw new ArgumentOutOfRangeException("positionNumber", positionNumber, null);
+				}
+			}
+
+			return new Vector2(TileSize.WIDTH * (positionNumber - 2),
+				WindowSize.HEIGHT * 0.5f - (TileSize.MARGIN_TOP + TileSize.HEIGHT * 0.5f) -
+				TileSize.HEIGHT * (positionNumber - 1));
 		}
 	}
 }

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/BulletGenerator.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/BulletGenerator.cs
@@ -16,7 +16,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
 		// Generatorが作成された時刻
 		public float startTime;
 
-		public enum Direction
+		public enum BulletDirection
 		{
 			ToLeft,
 			ToRight,
@@ -68,12 +68,12 @@ namespace Project.Scripts.GamePlayScene.Bullet
 					// 銃弾を作るインターバル
 					const float createInterval = 1.0f;
 					// coroutineのリスト
-					coroutines.Add(CreateBullet(Direction.ToLeft, (int) ToLeft.First, appearanceTime, createInterval));
-					coroutines.Add(CreateBullet(Direction.ToRight, (int) ToRight.Second, appearanceTime: 2.0f,
+					coroutines.Add(CreateBullet(BulletDirection.ToLeft, (int) ToLeft.First, appearanceTime, createInterval));
+					coroutines.Add(CreateBullet(BulletDirection.ToRight, (int) ToRight.Second, appearanceTime: 2.0f,
 						interval: 4.0f));
 					break;
 				case 2:
-					coroutines.Add(CreateBullet(Direction.ToRight, (int) ToRight.Fifth, appearanceTime: 2.0f, interval: 4.0f));
+					coroutines.Add(CreateBullet(BulletDirection.ToRight, (int) ToRight.Fifth, appearanceTime: 2.0f, interval: 4.0f));
 					break;
 				default:
 					throw new NotImplementedException();
@@ -83,7 +83,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
 		}
 
 		// 指定した座標(x, y)に一定の時間間隔(interval)で銃弾を作成するメソッド
-		private IEnumerator CreateBullet(Direction direction, int line, float appearanceTime,
+		private IEnumerator CreateBullet(BulletDirection direction, int line, float appearanceTime,
 			float interval)
 		{
 			var currentTime = Time.time;

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/BulletGenerator.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/BulletGenerator.cs
@@ -16,7 +16,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
 		// Generatorが作成された時刻
 		public float startTime;
 
-		private enum Left
+		private enum ToLeft
 		{
 			First = 1,
 			Second,
@@ -25,7 +25,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
 			Fifth
 		}
 
-		private enum Right
+		private enum ToRight
 		{
 			First = 1,
 			Second,
@@ -34,14 +34,14 @@ namespace Project.Scripts.GamePlayScene.Bullet
 			Fifth
 		}
 
-		private enum Up
+		private enum ToUp
 		{
 			First = 1,
 			Second,
 			Third
 		}
 
-		private enum Down
+		private enum ToDown
 		{
 			First = 1,
 			Second,

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/BulletGenerator.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/BulletGenerator.cs
@@ -64,17 +64,16 @@ namespace Project.Scripts.GamePlayScene.Bullet
 			{
 				case 1:
 					// 銃弾の出現時刻
-					const float appearanceTiming = 1.0f;
+					const float appearanceTime = 1.0f;
 					// 銃弾を作るインターバル
 					const float createInterval = 1.0f;
 					// coroutineのリスト
-					coroutines.Add(CreateBullet(Direction.ToLeft, (int) ToLeft.First, appearanceTiming, createInterval));
-					coroutines.Add(CreateBullet(Direction.ToRight, (int) ToRight.Second, appearanceTiming: 2.0f,
+					coroutines.Add(CreateBullet(Direction.ToLeft, (int) ToLeft.First, appearanceTime, createInterval));
+					coroutines.Add(CreateBullet(Direction.ToRight, (int) ToRight.Second, appearanceTime: 2.0f,
 						interval: 4.0f));
 					break;
 				case 2:
-					coroutines.Add(CreateBullet(Direction.ToRight, (int) ToRight.Fifth, appearanceTiming: 2.0f,
-						interval: 4.0f));
+					coroutines.Add(CreateBullet(Direction.ToRight, (int) ToRight.Fifth, appearanceTime: 2.0f, interval: 4.0f));
 					break;
 				default:
 					throw new NotImplementedException();
@@ -84,14 +83,14 @@ namespace Project.Scripts.GamePlayScene.Bullet
 		}
 
 		// 指定した座標(x, y)に一定の時間間隔(interval)で銃弾を作成するメソッド
-		private IEnumerator CreateBullet(Direction direction, int position, float appearanceTiming,
+		private IEnumerator CreateBullet(Direction direction, int position, float appearanceTime,
 			float interval)
 		{
 			var currentTime = Time.time;
 
 			// wait by the time the first bullet warning emerge
 			// 1.0f equals to the period which the bullet warning is emerging
-			yield return new WaitForSeconds(appearanceTiming - 1.0f - (currentTime - startTime));
+			yield return new WaitForSeconds(appearanceTime - 1.0f - (currentTime - startTime));
 
 			// the number of bullets which have emerged
 			var sum = 0;
@@ -120,7 +119,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
 
 				currentTime = Time.time;
 				// 一定時間(interval)待つ
-				yield return new WaitForSeconds(appearanceTiming + interval * sum - (currentTime - startTime));
+				yield return new WaitForSeconds(appearanceTime + interval * sum - (currentTime - startTime));
 			}
 		}
 	}

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/BulletGenerator.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/BulletGenerator.cs
@@ -69,10 +69,9 @@ namespace Project.Scripts.GamePlayScene.Bullet
 					break;
 				default:
 					throw new NotImplementedException();
-					break;
 			}
 
-			foreach (IEnumerator coroutine in coroutines) StartCoroutine(coroutine);
+			foreach (var coroutine in coroutines) StartCoroutine(coroutine);
 		}
 
 		// 銃弾の移動方向および出現させる位置を取得してCreatebullet()メソッドに引数を渡す
@@ -98,7 +97,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
 		}
 
 		// 指定した座標(x, y)に一定の時間間隔(interval)で銃弾を作成するメソッド
-		private IEnumerator CreateBullet(String direction, int position, float appearanceTiming,
+		private IEnumerator CreateBullet(string direction, int position, float appearanceTiming,
 			float interval)
 		{
 			var currentTime = Time.time;
@@ -114,17 +113,17 @@ namespace Project.Scripts.GamePlayScene.Bullet
 			{
 				sum++;
 				// normalBulletPrefabのGameObjectを作成
-				GameObject bullet = Instantiate(normalBulletPrefab);
+				var bullet = Instantiate(normalBulletPrefab);
 				// SortingLayerを指定
 				bullet.GetComponent<Renderer>().sortingLayerName = "Bullet";
 				// 変数の初期設定
-				NormalCartridgeController cartridgeScript = bullet.GetComponent<NormalCartridgeController>();
+				var cartridgeScript = bullet.GetComponent<NormalCartridgeController>();
 				cartridgeScript.Initialize(direction, position);
 
 				// emerge a bullet warning
 				GameObject warning = Instantiate(normalBulletWarningPrefab);
 				warning.GetComponent<Renderer>().sortingLayerName = "Warning";
-				NormalCartridgeWarningController warningScript =
+				var warningScript =
 					warning.GetComponent<NormalCartridgeWarningController>();
 				warningScript.Initialize(bullet.transform.position, cartridgeScript.motionVector,
 					cartridgeScript.localScale, cartridgeScript.originalWidth, cartridgeScript.originalHeight);

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/BulletGenerator.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/BulletGenerator.cs
@@ -68,12 +68,13 @@ namespace Project.Scripts.GamePlayScene.Bullet
 					// 銃弾を作るインターバル
 					const float createInterval = 1.0f;
 					// coroutineのリスト
-					AddCoroutine(coroutines, Left.First, appearanceTiming, createInterval);
-					AddCoroutine(coroutine: coroutines, row: Right.Second, appearanceTiming: 2.0f,
-						createInterval: 4.0f);
+					coroutines.Add(CreateBullet(Direction.ToLeft, (int) ToLeft.First, appearanceTiming, createInterval));
+					coroutines.Add(CreateBullet(Direction.ToRight, (int) ToRight.Second, appearanceTiming: 2.0f,
+						interval: 4.0f));
 					break;
 				case 2:
-					AddCoroutine(coroutine: coroutines, row: Right.Fifth, appearanceTiming: 2.0f, createInterval: 4.0f);
+					coroutines.Add(CreateBullet(Direction.ToRight, (int) ToRight.Fifth, appearanceTiming: 2.0f,
+						interval: 4.0f));
 					break;
 				default:
 					throw new NotImplementedException();
@@ -82,30 +83,8 @@ namespace Project.Scripts.GamePlayScene.Bullet
 			foreach (var coroutine in coroutines) StartCoroutine(coroutine);
 		}
 
-		// 銃弾の移動方向および出現させる位置を取得してCreatebullet()メソッドに引数を渡す
-		private void AddCoroutine(List<IEnumerator> coroutine, Left row, float appearanceTiming, float createInterval)
-		{
-			coroutine.Add(CreateBullet("left", (int) row, appearanceTiming, createInterval));
-		}
-
-		private void AddCoroutine(List<IEnumerator> coroutine, Right row, float appearanceTiming, float createInterval)
-		{
-			coroutine.Add(CreateBullet("right", (int) row, appearanceTiming, createInterval));
-		}
-
-		private void AddCoroutine(List<IEnumerator> coroutine, Up column, float appearanceTiming, float createInterval)
-		{
-			coroutine.Add(CreateBullet("up", (int) column, appearanceTiming, createInterval));
-		}
-
-		private void AddCoroutine(List<IEnumerator> coroutine, Down column, float appearanceTiming,
-			float createInterval)
-		{
-			coroutine.Add(CreateBullet("down", (int) column, appearanceTiming, createInterval));
-		}
-
 		// 指定した座標(x, y)に一定の時間間隔(interval)で銃弾を作成するメソッド
-		private IEnumerator CreateBullet(string direction, int position, float appearanceTiming,
+		private IEnumerator CreateBullet(Direction direction, int position, float appearanceTiming,
 			float interval)
 		{
 			var currentTime = Time.time;

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/BulletGenerator.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/BulletGenerator.cs
@@ -83,7 +83,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
 		}
 
 		// 指定した座標(x, y)に一定の時間間隔(interval)で銃弾を作成するメソッド
-		private IEnumerator CreateBullet(Direction direction, int position, float appearanceTime,
+		private IEnumerator CreateBullet(Direction direction, int line, float appearanceTime,
 			float interval)
 		{
 			var currentTime = Time.time;
@@ -104,7 +104,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
 				bullet.GetComponent<Renderer>().sortingLayerName = "Bullet";
 				// 変数の初期設定
 				var cartridgeScript = bullet.GetComponent<NormalCartridgeController>();
-				cartridgeScript.Initialize(direction, position);
+				cartridgeScript.Initialize(direction, line);
 
 				// emerge a bullet warning
 				GameObject warning = Instantiate(normalBulletWarningPrefab);

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/CartridgeController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/CartridgeController.cs
@@ -45,29 +45,29 @@ namespace Project.Scripts.GamePlayScene.Bullet
 		}
 
 		// 銃弾の初期配置の設定
-		protected void SetInitialPosition(String direction, int position)
+		protected void SetInitialPosition(BulletGenerator.Direction direction, int line)
 		{
 			switch (direction)
 			{
-				case "left":
+				case BulletGenerator.Direction.ToLeft:
 					transform.position = new Vector2((WindowSize.WIDTH + localScale * originalWidth) / 2,
 						WindowSize.HEIGHT * 0.5f - (TileSize.MARGIN_TOP + TileSize.HEIGHT * 0.5f) -
-						TileSize.HEIGHT * (position - 1));
+						TileSize.HEIGHT * (line - 1));
 					motionVector = Vector2.left;
 					break;
-				case "right":
+				case BulletGenerator.Direction.ToRight:
 					transform.position = new Vector2(-(WindowSize.WIDTH + localScale * originalWidth) / 2,
 						WindowSize.HEIGHT * 0.5f - (TileSize.MARGIN_TOP + TileSize.HEIGHT * 0.5f) -
-						TileSize.HEIGHT * (position - 1));
+						TileSize.HEIGHT * (line - 1));
 					motionVector = Vector2.right;
 					break;
-				case "up":
-					transform.position = new Vector2(TileSize.WIDTH * (position - 2),
+				case BulletGenerator.Direction.ToUp:
+					transform.position = new Vector2(TileSize.WIDTH * (line - 2),
 						-(WindowSize.HEIGHT + localScale * originalHeight) / 2);
 					motionVector = Vector2.up;
 					break;
-				case "down":
-					transform.position = new Vector2(TileSize.WIDTH * (position - 2),
+				case BulletGenerator.Direction.ToBottom:
+					transform.position = new Vector2(TileSize.WIDTH * (line - 2),
 						(WindowSize.HEIGHT + localScale * originalHeight) / 2);
 					motionVector = Vector2.down;
 					break;

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/CartridgeController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/CartridgeController.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using Project.Scripts.Library.Data;
 using UnityEngine;
 
@@ -44,22 +45,37 @@ namespace Project.Scripts.GamePlayScene.Bullet
 		}
 
 		// 銃弾の初期配置の設定
-		protected void SetInitialPosition(Vector2 position, Vector2 motionVector)
+		protected void SetInitialPosition(String direction, int position)
 		{
-			if (motionVector.Equals(Vector2.right))
-				transform.position = new Vector2(-(WindowSize.WIDTH + localScale * originalWidth) / 2,
-					position.y);
-			else if (motionVector.Equals(Vector2.left))
-				transform.position = new Vector2((WindowSize.WIDTH + localScale * originalWidth) / 2,
-					position.y);
-			else if (motionVector.Equals(Vector2.up))
-				transform.position = new Vector2(position.x, -(WindowSize.HEIGHT + localScale * originalHeight) / 2);
-			else if (motionVector.Equals(Vector2.down))
-				transform.position = new Vector2(position.x, (WindowSize.HEIGHT + localScale * originalHeight) / 2);
+			switch (direction)
+			{
+				case "left":
+					transform.position = new Vector2((WindowSize.WIDTH + localScale * originalWidth) / 2,
+						WindowSize.HEIGHT * 0.5f - (TileSize.MARGIN_TOP + TileSize.HEIGHT * 0.5f) -
+						TileSize.HEIGHT * (position - 1));
+					motionVector = Vector2.left;
+					break;
+				case "right":
+					transform.position = new Vector2(-(WindowSize.WIDTH + localScale * originalWidth) / 2,
+						WindowSize.HEIGHT * 0.5f - (TileSize.MARGIN_TOP + TileSize.HEIGHT * 0.5f) -
+						TileSize.HEIGHT * (position - 1));
+					motionVector = Vector2.right;
+					break;
+				case "up":
+					transform.position = new Vector2(TileSize.WIDTH * (position - 2),
+						-(WindowSize.HEIGHT + localScale * originalHeight) / 2);
+					motionVector = Vector2.up;
+					break;
+				case "down":
+					transform.position = new Vector2(TileSize.WIDTH * (position - 2),
+						(WindowSize.HEIGHT + localScale * originalHeight) / 2);
+					motionVector = Vector2.down;
+					break;
+			}
+
 			// Check if a bullet should be flipped vertically
 			transform.localScale *= new Vector2(localScale, -1 * Mathf.Sign(motionVector.x) * localScale);
 
-			this.motionVector = motionVector;
 			// Calculate rotation angle
 			var angle = Vector2.Dot(motionVector, Vector2.left) / motionVector.magnitude;
 			angle = (float) (Mathf.Acos(angle) * 180 / Math.PI);

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/CartridgeController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/CartridgeController.cs
@@ -45,28 +45,28 @@ namespace Project.Scripts.GamePlayScene.Bullet
 		}
 
 		// 銃弾の初期配置の設定
-		protected void SetInitialPosition(BulletGenerator.Direction direction, int line)
+		protected void SetInitialPosition(BulletGenerator.BulletDirection direction, int line)
 		{
 			switch (direction)
 			{
-				case BulletGenerator.Direction.ToLeft:
+				case BulletGenerator.BulletDirection.ToLeft:
 					transform.position = new Vector2((WindowSize.WIDTH + localScale * originalWidth) / 2,
 						WindowSize.HEIGHT * 0.5f - (TileSize.MARGIN_TOP + TileSize.HEIGHT * 0.5f) -
 						TileSize.HEIGHT * (line - 1));
 					motionVector = Vector2.left;
 					break;
-				case BulletGenerator.Direction.ToRight:
+				case BulletGenerator.BulletDirection.ToRight:
 					transform.position = new Vector2(-(WindowSize.WIDTH + localScale * originalWidth) / 2,
 						WindowSize.HEIGHT * 0.5f - (TileSize.MARGIN_TOP + TileSize.HEIGHT * 0.5f) -
 						TileSize.HEIGHT * (line - 1));
 					motionVector = Vector2.right;
 					break;
-				case BulletGenerator.Direction.ToUp:
+				case BulletGenerator.BulletDirection.ToUp:
 					transform.position = new Vector2(TileSize.WIDTH * (line - 2),
 						-(WindowSize.HEIGHT + localScale * originalHeight) / 2);
 					motionVector = Vector2.up;
 					break;
-				case BulletGenerator.Direction.ToBottom:
+				case BulletGenerator.BulletDirection.ToBottom:
 					transform.position = new Vector2(TileSize.WIDTH * (line - 2),
 						(WindowSize.HEIGHT + localScale * originalHeight) / 2);
 					motionVector = Vector2.down;

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/NormalCartridgeController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/NormalCartridgeController.cs
@@ -1,4 +1,5 @@
-﻿using Project.Scripts.Library.Data;
+﻿using System;
+using Project.Scripts.Library.Data;
 using UnityEngine;
 
 namespace Project.Scripts.GamePlayScene.Bullet
@@ -6,14 +7,14 @@ namespace Project.Scripts.GamePlayScene.Bullet
 	public class NormalCartridgeController : CartridgeController
 	{
 		// コンストラクタがわりのメソッド
-		public void Initialize(Vector2 position, Vector2 motionVector)
+		public void Initialize(String direction, int position)
 		{
 			speed = 0.1f;
 			originalWidth = GetComponent<Renderer>().bounds.size.x;
 			originalHeight = GetComponent<Renderer>().bounds.size.y;
 			localScale = (float) (WindowSize.WIDTH * 0.15);
 
-			SetInitialPosition(position, motionVector);
+			SetInitialPosition(direction, position);
 		}
 	}
 }

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/NormalCartridgeController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/NormalCartridgeController.cs
@@ -7,7 +7,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
 	public class NormalCartridgeController : CartridgeController
 	{
 		// コンストラクタがわりのメソッド
-		public void Initialize(BulletGenerator.Direction direction, int line)
+		public void Initialize(BulletGenerator.BulletDirection direction, int line)
 		{
 			speed = 0.1f;
 			originalWidth = GetComponent<Renderer>().bounds.size.x;

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/NormalCartridgeController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/NormalCartridgeController.cs
@@ -7,14 +7,14 @@ namespace Project.Scripts.GamePlayScene.Bullet
 	public class NormalCartridgeController : CartridgeController
 	{
 		// コンストラクタがわりのメソッド
-		public void Initialize(String direction, int position)
+		public void Initialize(BulletGenerator.Direction direction, int line)
 		{
 			speed = 0.1f;
 			originalWidth = GetComponent<Renderer>().bounds.size.x;
 			originalHeight = GetComponent<Renderer>().bounds.size.y;
 			localScale = (float) (WindowSize.WIDTH * 0.15);
 
-			SetInitialPosition(direction, position);
+			SetInitialPosition(direction, line);
 		}
 	}
 }

--- a/Assets/Project/Scripts/GamePlayScene/Panel/PanelGenerator.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Panel/PanelGenerator.cs
@@ -43,7 +43,6 @@ namespace Project.Scripts.GamePlayScene.Panel
 					break;
 				default:
 					throw new NotImplementedException();
-					break;
 			}
 		}
 


### PR DESCRIPTION
## 対象イシュー
https://app.mmth.pro/projects/18382/tasks#/show/158544

## 概要
タイルの中央部分を通過するように銃弾の位置を設定する

## 技術的な内容
- BulletGeneratorクラス
銃弾の方向を表す`Left`,`Right`,`Up`,`Bottom`の4つのenumを定義。
それぞれのenumには取りうる行数(もしくは列数)が定義されている。

- Bulletクラスの子クラス
銃弾の方向および行数(もしくは列数)をもとに銃弾の初期位置および移動方向を設定する。

## キャプチャ
