### PR TITLE
Componentのアタッチをコードで行うようにする

### DIFF
--- a/Assets/Project/Prefabs/GamePlayScene/Bullet/normalBulletPrefab.prefab
+++ b/Assets/Project/Prefabs/GamePlayScene/Bullet/normalBulletPrefab.prefab
@@ -21,8 +21,6 @@ GameObject:
   - component: {fileID: 4363906504938260}
   - component: {fileID: 212451907916449790}
   - component: {fileID: 114617676760384634}
-  - component: {fileID: 61310658898925918}
-  - component: {fileID: 50387757309684714}
   m_Layer: 0
   m_Name: normalBulletPrefab
   m_TagString: Bullet
@@ -43,51 +41,6 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!50 &50387757309684714
-Rigidbody2D:
-  serializedVersion: 4
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1336118223516990}
-  m_BodyType: 0
-  m_Simulated: 1
-  m_UseFullKinematicContacts: 0
-  m_UseAutoMass: 0
-  m_Mass: 1
-  m_LinearDrag: 0
-  m_AngularDrag: 0.05
-  m_GravityScale: 0
-  m_Material: {fileID: 0}
-  m_Interpolate: 0
-  m_SleepingMode: 1
-  m_CollisionDetection: 0
-  m_Constraints: 0
---- !u!61 &61310658898925918
-BoxCollider2D:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1336118223516990}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
-  m_SpriteTilingProperty:
-    border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0.5, y: 0.5}
-    oldSize: {x: 1.5, y: 0.5}
-    newSize: {x: 1.5, y: 0.5}
-    adaptiveTilingThreshold: 0.5
-    drawMode: 0
-    adaptiveTiling: 0
-  m_AutoTiling: 0
-  serializedVersion: 2
-  m_Size: {x: 1.5, y: 0.5}
-  m_EdgeRadius: 0
 --- !u!114 &114617676760384634
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -99,6 +52,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 3774f8febe87f444c8912a134322f0fc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  additionalMargin: 0.00001
+  localScale: 0
+  motionVector: {x: 0, y: 0}
+  speed: 0
+  originalWidth: 0
+  originalHeight: 0
 --- !u!212 &212451907916449790
 SpriteRenderer:
   m_ObjectHideFlags: 1

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/CartridgeController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/CartridgeController.cs
@@ -31,8 +31,9 @@ namespace Project.Scripts.GamePlayScene.Bullet
 		{
 			// BocCollider2Dのアタッチメント
 			gameObject.AddComponent<BoxCollider2D>();
-			gameObject.GetComponent<BoxCollider2D>().offset = new Vector2(-(1.5f-(WindowSize.WIDTH * 0.24f * 0.1f))/2, 0);
-			gameObject.GetComponent<BoxCollider2D>().size = new Vector2(WindowSize.WIDTH * 0.24f * 0.1f,0.5f);
+			gameObject.GetComponent<BoxCollider2D>().offset =
+				new Vector2(-(1.5f - (WindowSize.WIDTH * 0.24f * 0.1f)) / 2, 0);
+			gameObject.GetComponent<BoxCollider2D>().size = new Vector2(WindowSize.WIDTH * 0.24f * 0.1f, 0.5f);
 			gameObject.GetComponent<BoxCollider2D>().isTrigger = true;
 			// RigidBodyのアタッチメント
 			gameObject.AddComponent<Rigidbody2D>();

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/CartridgeController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/CartridgeController.cs
@@ -33,7 +33,8 @@ namespace Project.Scripts.GamePlayScene.Bullet
 			gameObject.AddComponent<BoxCollider2D>();
 			gameObject.GetComponent<BoxCollider2D>().offset =
 				new Vector2(-(1.5f - (WindowSize.WIDTH * 0.24f * 0.1f)) / 2, 0);
-			gameObject.GetComponent<BoxCollider2D>().size = new Vector2(WindowSize.WIDTH * 0.24f * 0.1f, 0.5f);
+			// 銃弾の先頭部分のみに当たり判定を与える
+			gameObject.GetComponent<BoxCollider2D>().size = new Vector2(TileSize.WIDTH - PanelSize.WIDTH, 0.5f);
 			gameObject.GetComponent<BoxCollider2D>().isTrigger = true;
 			// RigidBodyのアタッチメント
 			gameObject.AddComponent<Rigidbody2D>();

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/CartridgeController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/CartridgeController.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections;
 using Project.Scripts.Library.Data;
 using UnityEngine;
 
@@ -32,9 +31,9 @@ namespace Project.Scripts.GamePlayScene.Bullet
 			// BocCollider2Dのアタッチメント
 			gameObject.AddComponent<BoxCollider2D>();
 			gameObject.GetComponent<BoxCollider2D>().offset =
-				new Vector2(-(1.5f - (WindowSize.WIDTH * 0.24f * 0.1f)) / 2, 0);
+				new Vector2(-(1.5f - WindowSize.WIDTH * 0.24f * 0.1f) / 2, 0);
 			// 銃弾の先頭部分のみに当たり判定を与える
-			gameObject.GetComponent<BoxCollider2D>().size = new Vector2((TileSize.WIDTH - PanelSize.WIDTH)/2, 0.5f);
+			gameObject.GetComponent<BoxCollider2D>().size = new Vector2((TileSize.WIDTH - PanelSize.WIDTH) / 2, 0.5f);
 			gameObject.GetComponent<BoxCollider2D>().isTrigger = true;
 			// RigidBodyのアタッチメント
 			gameObject.AddComponent<Rigidbody2D>();

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/CartridgeController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/CartridgeController.cs
@@ -30,9 +30,9 @@ namespace Project.Scripts.GamePlayScene.Bullet
 		{
 			// BocCollider2Dのアタッチメント
 			gameObject.AddComponent<BoxCollider2D>();
+			// 銃弾の先頭部分のみに当たり判定を与える
 			gameObject.GetComponent<BoxCollider2D>().offset =
 				new Vector2(-(1.5f - WindowSize.WIDTH * 0.24f * 0.1f) / 2, 0);
-			// 銃弾の先頭部分のみに当たり判定を与える
 			gameObject.GetComponent<BoxCollider2D>().size = new Vector2((TileSize.WIDTH - PanelSize.WIDTH) / 2, 0.5f);
 			gameObject.GetComponent<BoxCollider2D>().isTrigger = true;
 			// RigidBodyのアタッチメント

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/CartridgeController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/CartridgeController.cs
@@ -34,7 +34,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
 			gameObject.GetComponent<BoxCollider2D>().offset =
 				new Vector2(-(1.5f - (WindowSize.WIDTH * 0.24f * 0.1f)) / 2, 0);
 			// 銃弾の先頭部分のみに当たり判定を与える
-			gameObject.GetComponent<BoxCollider2D>().size = new Vector2(TileSize.WIDTH - PanelSize.WIDTH, 0.5f);
+			gameObject.GetComponent<BoxCollider2D>().size = new Vector2((TileSize.WIDTH - PanelSize.WIDTH)/2, 0.5f);
 			gameObject.GetComponent<BoxCollider2D>().isTrigger = true;
 			// RigidBodyのアタッチメント
 			gameObject.AddComponent<Rigidbody2D>();

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/CartridgeController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/CartridgeController.cs
@@ -29,6 +29,14 @@ namespace Project.Scripts.GamePlayScene.Bullet
 
 		private void OnEnable()
 		{
+			// BocCollider2Dのアタッチメント
+			gameObject.AddComponent<BoxCollider2D>();
+			gameObject.GetComponent<BoxCollider2D>().offset = new Vector2(-(1.5f-(WindowSize.WIDTH * 0.24f * 0.1f))/2, 0);
+			gameObject.GetComponent<BoxCollider2D>().size = new Vector2(WindowSize.WIDTH * 0.24f * 0.1f,0.5f);
+			gameObject.GetComponent<BoxCollider2D>().isTrigger = true;
+			// RigidBodyのアタッチメント
+			gameObject.AddComponent<Rigidbody2D>();
+			gameObject.GetComponent<Rigidbody2D>().gravityScale = 0f;
 			GamePlayDirector.OnSucceed += OnSucceed;
 			GamePlayDirector.OnFail += OnFail;
 		}

--- a/Assets/Project/Scripts/GamePlayScene/Panel/DynamicPanelController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Panel/DynamicPanelController.cs
@@ -12,15 +12,11 @@ namespace Project.Scripts.GamePlayScene.Panel
 		protected virtual void Start()
 		{
 			gamePlayDirector = FindObjectOfType<GamePlayDirector>();
-			// 当たり判定をパネルサイズと同等にする
-			Vector2 panelSize = transform.localScale * 2f;
-			var panelCollider = GetComponent<BoxCollider2D>();
-			panelCollider.size = panelSize;
 		}
 
 		private void OnEnable()
 		{
-			// 当たり判定と，フリック検知のアタッチ（いちいちUIで設定したくない）
+			// 当たり判定と，フリック検知のアタッチ
 			gameObject.AddComponent<BoxCollider2D>();
 			gameObject.AddComponent<FlickGesture>();
 			GetComponent<FlickGesture>().Flicked += HandleFlick;


### PR DESCRIPTION
## 対象イシュー
https://app.mmth.pro/projects/18382/tasks#/show/196579
https://app.mmth.pro/projects/18382/tasks#/show/195447

## 概要
GUIを用いずにPanelおよびBulletのcolliderをアタッチする。
Bulletのcolliderを銃弾の先頭部分のみにする。

## 技術的な内容
アタッチされたcolliderは、objectのsizeが変更されたときに、同様にsizeが変更される模様。

## キャプチャ
