### PR TITLE
銃弾画像の大きさ設定にマジックナンバーを用いない

### DIFF
--- a/Assets/Project/Scripts/GamePlayScene/Bullet/CartridgeController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/CartridgeController.cs
@@ -31,9 +31,10 @@ namespace Project.Scripts.GamePlayScene.Bullet
 			// BocCollider2Dのアタッチメント
 			gameObject.AddComponent<BoxCollider2D>();
 			// 銃弾の先頭部分のみに当たり判定を与える
+			const float betweenPanels = TileSize.WIDTH * 0.1f;
 			gameObject.GetComponent<BoxCollider2D>().offset =
-				new Vector2(-(1.5f - WindowSize.WIDTH * 0.24f * 0.1f) / 2, 0);
-			gameObject.GetComponent<BoxCollider2D>().size = new Vector2((TileSize.WIDTH - PanelSize.WIDTH) / 2, 0.5f);
+				new Vector2(-(originalWidth - betweenPanels) / 2, 0);
+			gameObject.GetComponent<BoxCollider2D>().size = new Vector2((TileSize.WIDTH - PanelSize.WIDTH) / 2, originalHeight);
 			gameObject.GetComponent<BoxCollider2D>().isTrigger = true;
 			// RigidBodyのアタッチメント
 			gameObject.AddComponent<Rigidbody2D>();

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/CartridgeController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/CartridgeController.cs
@@ -34,7 +34,8 @@ namespace Project.Scripts.GamePlayScene.Bullet
 			const float betweenPanels = TileSize.WIDTH * 0.1f;
 			gameObject.GetComponent<BoxCollider2D>().offset =
 				new Vector2(-(originalWidth - betweenPanels) / 2, 0);
-			gameObject.GetComponent<BoxCollider2D>().size = new Vector2((TileSize.WIDTH - PanelSize.WIDTH) / 2, originalHeight);
+			gameObject.GetComponent<BoxCollider2D>().size =
+				new Vector2((TileSize.WIDTH - PanelSize.WIDTH) / 2, originalHeight);
 			gameObject.GetComponent<BoxCollider2D>().isTrigger = true;
 			// RigidBodyのアタッチメント
 			gameObject.AddComponent<Rigidbody2D>();

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/CartridgeController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/CartridgeController.cs
@@ -36,7 +36,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
 			// 銃弾の先頭部分のみに当たり判定を与える
 			const float betweenPanels = TileSize.WIDTH - PanelSize.WIDTH;
 			gameObject.GetComponent<BoxCollider2D>().offset =
-				new Vector2(-(originalWidth - betweenPanels/2) / 2, 0);
+				new Vector2(-(originalWidth - betweenPanels / 2) / 2, 0);
 			gameObject.GetComponent<BoxCollider2D>().size =
 				new Vector2(betweenPanels / 2, originalHeight);
 			gameObject.GetComponent<BoxCollider2D>().isTrigger = true;

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/CartridgeController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/CartridgeController.cs
@@ -28,14 +28,17 @@ namespace Project.Scripts.GamePlayScene.Bullet
 
 		private void OnEnable()
 		{
+			originalWidth = GetComponent<SpriteRenderer>().bounds.size.x;
+			originalHeight = GetComponent<SpriteRenderer>().bounds.size.y;
+
 			// BocCollider2Dのアタッチメント
 			gameObject.AddComponent<BoxCollider2D>();
 			// 銃弾の先頭部分のみに当たり判定を与える
-			const float betweenPanels = TileSize.WIDTH * 0.1f;
+			const float betweenPanels = TileSize.WIDTH - PanelSize.WIDTH;
 			gameObject.GetComponent<BoxCollider2D>().offset =
-				new Vector2(-(originalWidth - betweenPanels) / 2, 0);
+				new Vector2(-(originalWidth - betweenPanels/2) / 2, 0);
 			gameObject.GetComponent<BoxCollider2D>().size =
-				new Vector2((TileSize.WIDTH - PanelSize.WIDTH) / 2, originalHeight);
+				new Vector2(betweenPanels / 2, originalHeight);
 			gameObject.GetComponent<BoxCollider2D>().isTrigger = true;
 			// RigidBodyのアタッチメント
 			gameObject.AddComponent<Rigidbody2D>();

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/NormalCartridgeController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/NormalCartridgeController.cs
@@ -10,8 +10,8 @@ namespace Project.Scripts.GamePlayScene.Bullet
 		public void Initialize(BulletGenerator.BulletDirection direction, int line)
 		{
 			speed = 0.1f;
-			originalWidth = GetComponent<Renderer>().bounds.size.x;
-			originalHeight = GetComponent<Renderer>().bounds.size.y;
+			originalWidth = GetComponent<SpriteRenderer>().bounds.size.x;
+			originalHeight = GetComponent<SpriteRenderer>().bounds.size.y;
 			localScale = (float) (WindowSize.WIDTH * 0.15);
 
 			SetInitialPosition(direction, line);

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/NormalCartridgeController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/NormalCartridgeController.cs
@@ -10,8 +10,6 @@ namespace Project.Scripts.GamePlayScene.Bullet
 		public void Initialize(BulletGenerator.BulletDirection direction, int line)
 		{
 			speed = 0.1f;
-			originalWidth = GetComponent<SpriteRenderer>().bounds.size.x;
-			originalHeight = GetComponent<SpriteRenderer>().bounds.size.y;
 			localScale = (float) (WindowSize.WIDTH * 0.15);
 
 			SetInitialPosition(direction, line);

--- a/Assets/Project/Scripts/GamePlayScene/BulletWarning/NormalCartridgeWarningController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/BulletWarning/NormalCartridgeWarningController.cs
@@ -9,8 +9,8 @@ namespace Project.Scripts.GamePlayScene.BulletWarning
 			float bulletWidth, float bulletHeight)
 		{
 			localScale = (float) (WindowSize.WIDTH * 0.15);
-			originalWidth = GetComponent<Renderer>().bounds.size.x;
-			originalHeight = GetComponent<Renderer>().bounds.size.y;
+			originalWidth = GetComponent<SpriteRenderer>().bounds.size.x;
+			originalHeight = GetComponent<SpriteRenderer>().bounds.size.y;
 			transform.localScale *= new Vector2(localScale, localScale);
 			transform.position = bulletPosition + Vector2.Scale(bulletMotionVector,
 				                     new Vector2((bulletLocalScale * bulletWidth + localScale * originalWidth) / 2,


### PR DESCRIPTION
## 対象イシュー
https://app.mmth.pro/projects/18382/tasks#/show/206200

## 概要
銃弾および銃弾の警告画像の大きさを取得し、マジックナンバーを用いないようにする

## 技術的な内容
特にない

## キャプチャ
