### PR TITLE
ゲーム成功時に、銃弾が全て消えず、新たに数個作成される問題を修正

### DIFF
--- a/Assets/Project/Scripts/GamePlayScene/Bullet/BulletGenerator.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/BulletGenerator.cs
@@ -18,9 +18,23 @@ namespace Project.Scripts.GamePlayScene.Bullet
 		// Generatorが作成された時刻
 		public float startTime;
 
+		private List<IEnumerator> coroutines;
+
+		private void OnEnable()
+		{
+			GamePlayDirector.OnSucceed += OnSucceed;
+			GamePlayDirector.OnFail += OnFail;
+		}
+
+		private void OnDisable()
+		{
+			GamePlayDirector.OnSucceed -= OnSucceed;
+			GamePlayDirector.OnFail -= OnFail;
+		}
+
 		public void CreateBullets(int stageId)
 		{
-			List<IEnumerator> coroutines = new List<IEnumerator>();
+			coroutines = new List<IEnumerator>();
 			startTime = Time.time;
 			switch (stageId)
 			{
@@ -78,15 +92,12 @@ namespace Project.Scripts.GamePlayScene.Bullet
 				// 変数の初期設定
 				var cartridgeScript = cartridge.GetComponent<CartridgeController>();
 				cartridgeScript.Initialize(direction, line);
-
 				// emerge a bullet warning
 				var warningScript = warning.GetComponent<CartridgeWarningController>();
 				warningScript.Initialize(cartridge.transform.position, cartridgeScript.motionVector,
 					cartridgeScript.localScale, cartridgeScript.originalWidth, cartridgeScript.originalHeight);
-
 				// delete the bullet warning
 				warningScript.DeleteWarning(cartridge);
-
 				// 一定時間(interval)待つ
 				currentTime = Time.time;
 				yield return new WaitForSeconds(appearanceTime - BulletWarningController.WARNING_DISPLAYED_TIME +
@@ -133,6 +144,22 @@ namespace Project.Scripts.GamePlayScene.Bullet
 				yield return new WaitForSeconds(appearanceTime - BulletWarningController.WARNING_DISPLAYED_TIME +
 				                                interval * sum - (currentTime - startTime));
 			}
+		}
+
+		private void OnSucceed()
+		{
+			GameFinish();
+		}
+
+		private void OnFail()
+		{
+			GameFinish();
+		}
+
+		private void GameFinish()
+		{
+			foreach (var coroutine in coroutines) StopCoroutine(coroutine);
+			Destroy(gameObject);
 		}
 	}
 }

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/BulletGenerator.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/BulletGenerator.cs
@@ -159,7 +159,6 @@ namespace Project.Scripts.GamePlayScene.Bullet
 		private void GameFinish()
 		{
 			foreach (var coroutine in coroutines) StopCoroutine(coroutine);
-			Destroy(gameObject);
 		}
 	}
 }

--- a/Assets/Project/Scripts/GamePlayScene/GamePlayDirector.cs
+++ b/Assets/Project/Scripts/GamePlayScene/GamePlayDirector.cs
@@ -167,10 +167,10 @@ namespace Project.Scripts.GamePlayScene
 
 		private void GameSucceed()
 		{
+			if (OnSucceed != null) OnSucceed();
 			GameFinish();
 			successAudioSource.Play();
 			resultText.GetComponent<Text>().text = "成功!";
-			if (OnSucceed != null) OnSucceed();
 			var ss = StageStatus.Get(stageId);
 			// クリア済みにする
 			ss.ClearStage(stageId);
@@ -180,10 +180,10 @@ namespace Project.Scripts.GamePlayScene
 
 		private void GameFail()
 		{
+			if (OnFail != null) OnFail();
 			GameFinish();
 			failureAudioSource.Play();
 			resultText.GetComponent<Text>().text = "失敗!";
-			if (OnFail != null) OnFail();
 			// 失敗回数をインクリメント
 			var ss = StageStatus.Get(stageId);
 			ss.IncFailureNum(stageId);
@@ -193,6 +193,7 @@ namespace Project.Scripts.GamePlayScene
 		{
 			playingAudioSource.Stop();
 			resultWindow.SetActive(true);
+			Destroy(bulletGenerator);
 		}
 
 		public void RetryButtonDown()

--- a/Assets/Project/Scripts/GamePlayScene/GamePlayDirector.cs
+++ b/Assets/Project/Scripts/GamePlayScene/GamePlayDirector.cs
@@ -193,7 +193,6 @@ namespace Project.Scripts.GamePlayScene
 		{
 			playingAudioSource.Stop();
 			resultWindow.SetActive(true);
-			Destroy(bulletGenerator);
 		}
 
 		public void RetryButtonDown()


### PR DESCRIPTION
## 対象イシュー
https://app.mmth.pro/projects/18382/tasks#/show/209637

## 概要
タイトル通り

## 技術的な内容
ゲーム終了時にBulletGeneratorをDestroy()する前に、BulletGenerator内のcoroutineを全て停止させる

## バグの再現方法
ステージ1を想定。
BulletGenerator.csのcoroutines.Add()の1つ目、intervalを1.0fから0.01fに変更し、ゲームをクリアすると、バグが発生する。
BulletGenerator.csのcoroutines.Add()の2つ目はコメントアウトしとくと楽。

また、BulletWarningController.csのWARNING_DISPLAYED_TIMEを1.0fから2.0fに変更する。

## キャプチャ
