### PR TITLE
銃弾を生成順に描画する

### DIFF
--- a/Assets/Project/Scripts/GamePlayScene/Bullet/BulletGenerator.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/BulletGenerator.cs
@@ -81,6 +81,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
 				{
 					case CartridgeType.NormalCartridge:
 						cartridge = Instantiate(normalCartridgePrefab);
+						cartridge.GetComponent<Renderer>().sortingOrder = sum;
 						warning = Instantiate(normalCartridgeWarningPrefab);
 						break;
 					default:

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/BulletGenerator.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/BulletGenerator.cs
@@ -81,12 +81,14 @@ namespace Project.Scripts.GamePlayScene.Bullet
 				{
 					case CartridgeType.NormalCartridge:
 						cartridge = Instantiate(normalCartridgePrefab);
-						cartridge.GetComponent<Renderer>().sortingOrder = sum;
 						warning = Instantiate(normalCartridgeWarningPrefab);
 						break;
 					default:
 						throw new NotImplementedException();
 				}
+
+				cartridge.GetComponent<Renderer>().sortingOrder = sum;
+				warning.GetComponent<Renderer>().sortingOrder = sum;
 
 				// 変数の初期設定
 				var cartridgeScript = cartridge.GetComponent<CartridgeController>();
@@ -114,7 +116,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
 
 			var sum = 0;
 
-			while (true)
+			while (sum < 2147483647)
 			{
 				sum++;
 				GameObject hole;
@@ -128,6 +130,9 @@ namespace Project.Scripts.GamePlayScene.Bullet
 					default:
 						throw new NotImplementedException();
 				}
+
+				hole.GetComponent<Renderer>().sortingOrder = sum;
+				warning.GetComponent<Renderer>().sortingOrder = sum;
 
 				var holeScript = hole.GetComponent<HoleController>();
 				holeScript.Initialize(row, column);

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/BulletGenerator.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/BulletGenerator.cs
@@ -71,8 +71,8 @@ namespace Project.Scripts.GamePlayScene.Bullet
 
 			// the number of bullets which have emerged
 			var sum = 0;
-
-			while (true)
+			
+			while (sum < 2147483647)
 			{
 				sum++;
 				GameObject cartridge;

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/BulletGenerator.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/BulletGenerator.cs
@@ -77,6 +77,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
 
 			while (true)
 			{
+				sum++;
 				GameObject cartridge;
 				GameObject warning;
 				switch (cartridgeType)
@@ -106,7 +107,6 @@ namespace Project.Scripts.GamePlayScene.Bullet
 				try
 				{
 					bulletId = checked((short) (bulletId + 1));
-					sum = checked(sum + 1);
 				}
 				catch (OverflowException)
 				{
@@ -132,6 +132,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
 
 			while (true)
 			{
+				sum++;
 				GameObject hole;
 				GameObject warning;
 				switch (holeType)
@@ -160,7 +161,6 @@ namespace Project.Scripts.GamePlayScene.Bullet
 				try
 				{
 					bulletId = checked((short) (bulletId + 1));
-					sum = checked(sum + 1);
 				}
 				catch (OverflowException)
 				{

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/BulletGenerator.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/BulletGenerator.cs
@@ -18,6 +18,9 @@ namespace Project.Scripts.GamePlayScene.Bullet
 		// Generatorが作成された時刻
 		public float startTime;
 
+		// 生成された銃弾のID(sortingOrder)
+		private short bulletId = -32768;
+
 		private List<IEnumerator> coroutines;
 
 		private void OnEnable()
@@ -71,10 +74,9 @@ namespace Project.Scripts.GamePlayScene.Bullet
 
 			// the number of bullets which have emerged
 			var sum = 0;
-			
-			while (sum < 2147483647)
+
+			while (true)
 			{
-				sum++;
 				GameObject cartridge;
 				GameObject warning;
 				switch (cartridgeType)
@@ -87,8 +89,9 @@ namespace Project.Scripts.GamePlayScene.Bullet
 						throw new NotImplementedException();
 				}
 
-				cartridge.GetComponent<Renderer>().sortingOrder = sum;
-				warning.GetComponent<Renderer>().sortingOrder = sum;
+				var tempBulletId = bulletId;
+				cartridge.GetComponent<Renderer>().sortingOrder = tempBulletId;
+				warning.GetComponent<Renderer>().sortingOrder = tempBulletId;
 
 				// 変数の初期設定
 				var cartridgeScript = cartridge.GetComponent<CartridgeController>();
@@ -99,6 +102,17 @@ namespace Project.Scripts.GamePlayScene.Bullet
 					BulletController.LOCAL_SCALE, cartridgeScript.originalWidth, cartridgeScript.originalHeight);
 				// delete the bullet warning
 				warningScript.DeleteWarning(cartridge);
+
+				try
+				{
+					bulletId = checked((short) (bulletId + 1));
+					sum = checked(sum + 1);
+				}
+				catch (OverflowException)
+				{
+					break;
+				}
+
 				// 一定時間(interval)待つ
 				currentTime = Time.time;
 				yield return new WaitForSeconds(appearanceTime - BulletWarningController.WARNING_DISPLAYED_TIME +
@@ -116,9 +130,8 @@ namespace Project.Scripts.GamePlayScene.Bullet
 
 			var sum = 0;
 
-			while (sum < 2147483647)
+			while (true)
 			{
-				sum++;
 				GameObject hole;
 				GameObject warning;
 				switch (holeType)
@@ -131,8 +144,9 @@ namespace Project.Scripts.GamePlayScene.Bullet
 						throw new NotImplementedException();
 				}
 
-				hole.GetComponent<Renderer>().sortingOrder = sum;
-				warning.GetComponent<Renderer>().sortingOrder = sum;
+				var tempBulletId = bulletId;
+				hole.GetComponent<Renderer>().sortingOrder = tempBulletId;
+				warning.GetComponent<Renderer>().sortingOrder = tempBulletId;
 
 				var holeScript = hole.GetComponent<HoleController>();
 				holeScript.Initialize(row, column);
@@ -142,6 +156,16 @@ namespace Project.Scripts.GamePlayScene.Bullet
 
 				// delete the bullet warning
 				warningScript.DeleteWarning(hole);
+
+				try
+				{
+					bulletId = checked((short) (bulletId + 1));
+					sum = checked(sum + 1);
+				}
+				catch (OverflowException)
+				{
+					break;
+				}
 
 				// 一定時間(interval)待つ
 				currentTime = Time.time;


### PR DESCRIPTION
## 対象イシュー
https://app.mmth.pro/projects/18382/tasks#/show/213868

## 概要
ごく短い時間間隔で銃弾を出現させた時に、描画順序が定まっていないので、試行のたびに見た目が変わってしまう。

## 技術的な内容
\-銃弾オブジェクトのRender componentの変数sortingOrderを設定した。
sortingOrderは同一レイヤーのオブジェクトの描画順序を決める変数である。
\-無限に銃弾を出現させるのは怖いので、出現させた銃弾の累積個数が閾値(intの最大値=2147483647)を超えた時、銃弾の生成をやめる。（長長長長長時間銃弾を避け続ければ銃弾が出てこなくなるので、クリアできるようになる。）
\-銃弾の生成間隔(=interval)を0.01fとかにすると、sortingOrderの効能がわかりやすいと思います。

## キャプチャ
