### PR TITLE
遷移を使わず，ゲームのリトライを行う

### DIFF
--- a/Assets/Project/Prefabs/GamePlayScene/Tile/normalTilePrefab.prefab
+++ b/Assets/Project/Prefabs/GamePlayScene/Tile/normalTilePrefab.prefab
@@ -23,7 +23,7 @@ GameObject:
   - component: {fileID: 114271774500816028}
   m_Layer: 0
   m_Name: normalTilePrefab
-  m_TagString: Untagged
+  m_TagString: Tile
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/Project/Scripts/GamePlayScene/GamePlayDirector.cs
+++ b/Assets/Project/Scripts/GamePlayScene/GamePlayDirector.cs
@@ -174,7 +174,7 @@ namespace Project.Scripts.GamePlayScene
 		private void GameSucceed()
 		{
 			if (OnSucceed != null) OnSucceed();
-			GameFinish();
+			EndProcess();
 			successAudioSource.Play();
 			resultText.GetComponent<Text>().text = "成功!";
 			var ss = StageStatus.Get(stageId);
@@ -187,7 +187,7 @@ namespace Project.Scripts.GamePlayScene
 		private void GameFail()
 		{
 			if (OnFail != null) OnFail();
-			GameFinish();
+			EndProcess();
 			failureAudioSource.Play();
 			resultText.GetComponent<Text>().text = "失敗!";
 			// 失敗回数をインクリメント
@@ -195,7 +195,7 @@ namespace Project.Scripts.GamePlayScene
 			ss.IncFailureNum(stageId);
 		}
 
-		private void GameFinish()
+		private void EndProcess()
 		{
 			playingAudioSource.Stop();
 			resultWindow.SetActive(true);

--- a/Assets/Project/Scripts/GamePlayScene/GamePlayDirector.cs
+++ b/Assets/Project/Scripts/GamePlayScene/GamePlayDirector.cs
@@ -219,6 +219,23 @@ namespace Project.Scripts.GamePlayScene
 			SceneManager.LoadScene("MenuBarScene");
 		}
 
+		private static void CleanObject()
+		{
+			GameObject[] tiles = GameObject.FindGameObjectsWithTag("Tile");
+			foreach (var tile in tiles)
+			{
+				// タイルの削除 (に伴いパネルも削除される)
+				Destroy(tile);
+			}
+
+			GameObject[] bullets = GameObject.FindGameObjectsWithTag("Bullet");
+			foreach (var bullet in bullets)
+			{
+				// 銃弾の削除
+				Destroy(bullet);
+			}
+		}
+
 		private static void UnifyDisplay()
 		{
 			// 想定するデバイスのアスペクト比

--- a/Assets/Project/Scripts/GamePlayScene/GamePlayDirector.cs
+++ b/Assets/Project/Scripts/GamePlayScene/GamePlayDirector.cs
@@ -119,6 +119,7 @@ namespace Project.Scripts.GamePlayScene
 					if (state == GameState.Opening)
 					{
 						state = nextState;
+						GamePlaying();
 						return true;
 					}
 
@@ -158,13 +159,16 @@ namespace Project.Scripts.GamePlayScene
 			panelGenerator.GetComponent<PanelGenerator>().CreatePanels(stageId);
 			// 銃弾作成スクリプトを起動
 			bulletGenerator.GetComponent<BulletGenerator>().CreateBullets(stageId);
-			// Playing中の音源の再生
-			playingAudioSource.Play();
 
 			Destroy(tileGenerator);
 			Destroy(panelGenerator);
 			// 状態を変更する
 			Dispatch(GameState.Playing);
+		}
+
+		private void GamePlaying()
+		{
+			playingAudioSource.Play();
 		}
 
 		private void GameSucceed()

--- a/Assets/Project/Scripts/GamePlayScene/GamePlayDirector.cs
+++ b/Assets/Project/Scripts/GamePlayScene/GamePlayDirector.cs
@@ -160,9 +160,6 @@ namespace Project.Scripts.GamePlayScene
 			// 結果ウィンドウを非表示
 			resultWindow.SetActive(false);
 
-			// 銃弾ジェネレータをアクティブ化
-			bulletGenerator.SetActive(true);
-
 			// タイル作成スクリプトを起動
 			tileGenerator.GetComponent<TileGenerator>().CreateTiles(stageId);
 			// パネル作成スクリプトを起動
@@ -207,7 +204,6 @@ namespace Project.Scripts.GamePlayScene
 		{
 			playingAudioSource.Stop();
 			resultWindow.SetActive(true);
-			bulletGenerator.SetActive(false);
 		}
 
 		public void RetryButtonDown()

--- a/Assets/Project/Scripts/GamePlayScene/GamePlayDirector.cs
+++ b/Assets/Project/Scripts/GamePlayScene/GamePlayDirector.cs
@@ -230,14 +230,14 @@ namespace Project.Scripts.GamePlayScene
 			foreach (var tile in tiles)
 			{
 				// タイルの削除 (に伴いパネルも削除される)
-				Destroy(tile);
+				DestroyImmediate(tile);
 			}
 
 			GameObject[] bullets = GameObject.FindGameObjectsWithTag("Bullet");
 			foreach (var bullet in bullets)
 			{
 				// 銃弾の削除
-				Destroy(bullet);
+				DestroyImmediate(bullet);
 			}
 		}
 

--- a/Assets/Project/Scripts/GamePlayScene/GamePlayDirector.cs
+++ b/Assets/Project/Scripts/GamePlayScene/GamePlayDirector.cs
@@ -53,31 +53,20 @@ namespace Project.Scripts.GamePlayScene
 		private void Awake()
 		{
 			UnifyDisplay();
+
 			tileGenerator = GameObject.Find("TileGenerator");
 			panelGenerator = GameObject.Find("PanelGenerator");
 			bulletGenerator = GameObject.Find("BulletGenerator");
 
 			resultWindow = GameObject.Find("ResultWindow");
-			resultWindow.SetActive(false);
 
 			resultText = resultWindow.transform.Find("Result").gameObject;
 			warningText = resultWindow.transform.Find("Warning").gameObject;
 			stageNumberText = GameObject.Find("StageNumberText");
-			// 現在のステージ番号を格納
-			stageNumberText.GetComponent<Text>().text = stageId.ToString();
 
 			SetAudioSource();
-			GameOpening();
 
-			// StageStatusのデバッグ用
-			var stageStatus = StageStatus.Get(stageId);
-			var tmp = stageStatus.passed ? "クリア済み" : "未クリア";
-			print("-------------------------------");
-			print("ステージ" + stageId + "番は" + tmp + "です");
-			print("ステージ" + stageId + "番の挑戦回数は" + stageStatus.challengeNum + "回です");
-			print("ステージ" + stageId + "番の成功回数は" + stageStatus.successNum + "回です");
-			print("ステージ" + stageId + "番の失敗回数は" + stageStatus.failureNum + "回です");
-			print("-------------------------------");
+			GameOpening();
 		}
 
 		private void OnApplicationPause(bool pauseStatus)
@@ -153,6 +142,27 @@ namespace Project.Scripts.GamePlayScene
 
 		private void GameOpening()
 		{
+			CleanObject();
+
+			// StageStatusのデバッグ用
+			var stageStatus = StageStatus.Get(stageId);
+			var tmp = stageStatus.passed ? "クリア済み" : "未クリア";
+			print("-------------------------------");
+			print("ステージ" + stageId + "番は" + tmp + "です");
+			print("ステージ" + stageId + "番の挑戦回数は" + stageStatus.challengeNum + "回です");
+			print("ステージ" + stageId + "番の成功回数は" + stageStatus.successNum + "回です");
+			print("ステージ" + stageId + "番の失敗回数は" + stageStatus.failureNum + "回です");
+			print("-------------------------------");
+
+			// 現在のステージ番号を格納
+			stageNumberText.GetComponent<Text>().text = stageId.ToString();
+
+			// 結果ウィンドウを非表示
+			resultWindow.SetActive(false);
+
+			// 銃弾ジェネレータをアクティブ化
+			bulletGenerator.SetActive(true);
+
 			// タイル作成スクリプトを起動
 			tileGenerator.GetComponent<TileGenerator>().CreateTiles(stageId);
 			// パネル作成スクリプトを起動
@@ -160,8 +170,6 @@ namespace Project.Scripts.GamePlayScene
 			// 銃弾作成スクリプトを起動
 			bulletGenerator.GetComponent<BulletGenerator>().CreateBullets(stageId);
 
-			Destroy(tileGenerator);
-			Destroy(panelGenerator);
 			// 状態を変更する
 			Dispatch(GameState.Playing);
 		}
@@ -199,18 +207,15 @@ namespace Project.Scripts.GamePlayScene
 		{
 			playingAudioSource.Stop();
 			resultWindow.SetActive(true);
-			Destroy(bulletGenerator);
+			bulletGenerator.SetActive(false);
 		}
 
 		public void RetryButtonDown()
 		{
-			// 現在のScene名を取得する
-			var loadScene = SceneManager.GetActiveScene();
-			// Sceneの読み直し
-			SceneManager.LoadScene(loadScene.name);
 			// 挑戦回数をインクリメント
 			var ss = StageStatus.Get(stageId);
 			ss.IncChallengeNum(stageId);
+			Dispatch(GameState.Opening);
 		}
 
 		public void BackButtonDown()

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -7,6 +7,7 @@ TagManager:
   - Bullet
   - NumberPanel
   - BulletWarning
+  - Tile
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
## 対象イシュー
https://app.mmth.pro/projects/18382/tasks#/show/217222

## 概要
- ゲームのリトライをする場合に，自身の再遷移を行なっていたが，状態の変更による実装に変更
- 上記に伴い，`Tile`オブジェクトに`Tile`タグを追加

## 技術的な内容
- 親オブジェクトを削除した場合には，子オブジェクトも同時に削除されるっぽい
- 各種ジェネレーターを`Destroy()`してしまうと，再利用できないので，アクティブ化で対応
