### PR TITLE
警告の表示後に銃弾を生成する

### DIFF
--- a/Assets/Project/Scripts/GamePlayScene/Bullet/BulletGenerator.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/BulletGenerator.cs
@@ -111,7 +111,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
 				}
 				catch (OverflowException)
 				{
-					break;
+					gamePlayDirector.Dispatch(GamePlayDirector.GameState.Failure);
 				}
 
 				// 次の銃弾を作成する時刻まで待つ
@@ -189,7 +189,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
 				}
 				catch (OverflowException)
 				{
-					break;
+					gamePlayDirector.Dispatch(GamePlayDirector.GameState.Failure);
 				}
 
 				// 一定時間(interval)待つ

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/BulletGenerator.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/BulletGenerator.cs
@@ -81,8 +81,10 @@ namespace Project.Scripts.GamePlayScene.Bullet
 			while (true)
 			{
 				sum++;
-				GameObject warning;
 				var tempBulletId = bulletId;
+
+				// 作成するcartidgeの種類で分岐
+				GameObject warning;
 				switch (cartridgeType)
 				{
 					case CartridgeType.NormalCartridge:
@@ -92,15 +94,17 @@ namespace Project.Scripts.GamePlayScene.Bullet
 						throw new NotImplementedException();
 				}
 
+				// 同レイヤーのオブジェクトの描画順序の制御
 				warning.GetComponent<Renderer>().sortingOrder = tempBulletId;
 
-				// 変数の初期設定
+				// warningの位置・大きさ等の設定
 				var warningScript = warning.GetComponent<CartridgeWarningController>();
 				var bulletMotionVector = warningScript.Initialize(direction, line);
-
+				// warningの表示が終わる時刻を待ち、cartidgeを作成する
 				StartCoroutine(CreateCartridge(warning, cartridgeType, direction, line, bulletMotionVector,
 					tempBulletId));
 
+				// 作成する銃弾の個数の上限チェック
 				try
 				{
 					bulletId = checked((short) (bulletId + 1));
@@ -110,21 +114,23 @@ namespace Project.Scripts.GamePlayScene.Bullet
 					break;
 				}
 
-				// 一定時間(interval)待つ
+				// 次の銃弾を作成する時刻まで待つ
 				currentTime = Time.time;
 				yield return new WaitForSeconds(appearanceTime - BulletWarningController.WARNING_DISPLAYED_TIME +
 				                                interval * sum - (currentTime - startTime));
 			}
 		}
 
+		// warningの表示が終わる時刻を待ち、cartridgeを作成するメソッド
 		private IEnumerator CreateCartridge(GameObject warning, CartridgeType cartridgeType,
-			CartridgeDirection direction,
-			int line,
-			Vector2 motionVector, short cartridgeId)
+			CartridgeDirection direction, int line, Vector2 motionVector, short cartridgeId)
 		{
+			// 警告の表示時間だけ待つ
 			yield return new WaitForSeconds(BulletWarningController.WARNING_DISPLAYED_TIME);
+			// 警告を削除する
 			Destroy(warning);
 
+			// ゲームが続いているなら銃弾を作成する
 			if (gamePlayDirector.state == GamePlayDirector.GameState.Playing)
 			{
 				GameObject cartridge;
@@ -140,7 +146,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
 				// 変数の初期設定
 				var cartridgeScript = cartridge.GetComponent<CartridgeController>();
 				cartridgeScript.Initialize(direction, line, motionVector);
-
+				// 同レイヤーのオブジェクトの描画順序の制御
 				cartridge.GetComponent<Renderer>().sortingOrder = cartridgeId;
 			}
 		}
@@ -158,8 +164,9 @@ namespace Project.Scripts.GamePlayScene.Bullet
 			while (true)
 			{
 				sum++;
-				GameObject warning;
 				var tempBulletId = bulletId;
+
+				GameObject warning;
 				switch (holeType)
 				{
 					case HoleType.NormalHole:
@@ -171,11 +178,9 @@ namespace Project.Scripts.GamePlayScene.Bullet
 
 				warning.GetComponent<Renderer>().sortingOrder = tempBulletId;
 
-				// 変数の初期設定
 				var warningScript = warning.GetComponent<HoleWarningController>();
 				warningScript.Initialize(row, column);
 
-				// delete the bullet warning
 				StartCoroutine(CreateHole(warning, holeType, row, column, warning.transform.position, tempBulletId));
 
 				try
@@ -194,9 +199,9 @@ namespace Project.Scripts.GamePlayScene.Bullet
 			}
 		}
 
+		// warningの表示が終わる時刻を待ち、holeを作成するメソッド
 		private IEnumerator CreateHole(GameObject warning, HoleType holeType, int row, int column,
-			Vector3 holeWarningPosition,
-			short holeId)
+			Vector3 holeWarningPosition, short holeId)
 		{
 			yield return new WaitForSeconds(BulletWarningController.WARNING_DISPLAYED_TIME);
 			Destroy(warning);
@@ -213,7 +218,6 @@ namespace Project.Scripts.GamePlayScene.Bullet
 						throw new NotImplementedException();
 				}
 
-				// 変数の初期設定
 				var holeScript = hole.GetComponent<HoleController>();
 				holeScript.Initialize(row, column, holeWarningPosition);
 

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/BulletGenerator.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/BulletGenerator.cs
@@ -9,6 +9,8 @@ namespace Project.Scripts.GamePlayScene.Bullet
 {
 	public class BulletGenerator : MonoBehaviour
 	{
+		private GamePlayDirector gamePlayDirector;
+
 		// 銃弾および警告のprefab
 		public GameObject normalCartridgePrefab;
 		public GameObject normalCartridgeWarningPrefab;
@@ -37,6 +39,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
 
 		public void CreateBullets(int stageId)
 		{
+			gamePlayDirector = FindObjectOfType<GamePlayDirector>();
 			coroutines = new List<IEnumerator>();
 			startTime = Time.time;
 			switch (stageId)
@@ -121,21 +124,24 @@ namespace Project.Scripts.GamePlayScene.Bullet
 			var currentTime = Time.time;
 			yield return new WaitForSeconds(time - (currentTime - startTime));
 
-			GameObject cartridge;
-			switch (cartridgeType)
+			if (gamePlayDirector.state == GamePlayDirector.GameState.Playing)
 			{
-				case CartridgeType.NormalCartridge:
-					cartridge = Instantiate(normalCartridgePrefab);
-					break;
-				default:
-					throw new NotImplementedException();
+				GameObject cartridge;
+				switch (cartridgeType)
+				{
+					case CartridgeType.NormalCartridge:
+						cartridge = Instantiate(normalCartridgePrefab);
+						break;
+					default:
+						throw new NotImplementedException();
+				}
+
+				// 変数の初期設定
+				var cartridgeScript = cartridge.GetComponent<CartridgeController>();
+				cartridgeScript.Initialize(direction, line, motionVector);
+
+				cartridge.GetComponent<Renderer>().sortingOrder = cartridgeId;
 			}
-
-			// 変数の初期設定
-			var cartridgeScript = cartridge.GetComponent<CartridgeController>();
-			cartridgeScript.Initialize(direction, line, motionVector);
-
-			cartridge.GetComponent<Renderer>().sortingOrder = cartridgeId;
 		}
 
 		// 指定したパネルに一定の時間間隔(interval)で撃ち抜く銃弾を作成するメソッド
@@ -195,22 +201,25 @@ namespace Project.Scripts.GamePlayScene.Bullet
 			var currentTime = Time.time;
 			yield return new WaitForSeconds(time - (currentTime - startTime));
 
-			GameObject hole;
-			switch (holeType)
+			if (gamePlayDirector.state == GamePlayDirector.GameState.Playing)
 			{
-				case HoleType.NormalHole:
-					hole = Instantiate(normalHolePrefab);
-					break;
-				default:
-					throw new NotImplementedException();
+				GameObject hole;
+				switch (holeType)
+				{
+					case HoleType.NormalHole:
+						hole = Instantiate(normalHolePrefab);
+						break;
+					default:
+						throw new NotImplementedException();
+				}
+
+				// 変数の初期設定
+				var holeScript = hole.GetComponent<HoleController>();
+				holeScript.Initialize(row, column, holeWarningPosition);
+
+				hole.GetComponent<Renderer>().sortingOrder = holeId;
+				StartCoroutine(holeScript.Delete());
 			}
-
-			// 変数の初期設定
-			var holeScript = hole.GetComponent<HoleController>();
-			holeScript.Initialize(row, column, holeWarningPosition);
-
-			hole.GetComponent<Renderer>().sortingOrder = holeId;
-			StartCoroutine(holeScript.Delete());
 		}
 
 		private void OnSucceed()

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/BulletGenerator.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/BulletGenerator.cs
@@ -46,16 +46,16 @@ namespace Project.Scripts.GamePlayScene.Bullet
 			{
 				case 1:
 					// coroutineのリスト
-					coroutines.Add(SetCartridge(CartridgeType.NormalCartridge, CartridgeDirection.ToLeft,
-						(int) ToLeft.First, appearanceTime: 1.0f, interval: 1.0f));
-					coroutines.Add(SetCartridge(CartridgeType.NormalCartridge, CartridgeDirection.ToRight,
-						(int) ToRight.Second, appearanceTime: 2.0f, interval: 4.0f));
+					coroutines.Add(CreateCartridge(CartridgeType.NormalCartridge, CartridgeDirection.ToLeft,
+						(int) ToLeft.First, 1.0f, 1.0f));
+					coroutines.Add(CreateCartridge(CartridgeType.NormalCartridge, CartridgeDirection.ToRight,
+						(int) ToRight.Second, 2.0f, 4.0f));
 					break;
 				case 2:
-					coroutines.Add(SetCartridge(CartridgeType.NormalCartridge, CartridgeDirection.ToRight,
-						(int) ToRight.Fifth, appearanceTime: 2.0f, interval: 0.5f));
-					coroutines.Add(SetHole(HoleType.NormalHole, appearanceTime: 1.0f, interval: 2.0f,
-						row: (int) Row.Second, column: (int) Column.Left));
+					coroutines.Add(CreateCartridge(CartridgeType.NormalCartridge, CartridgeDirection.ToRight,
+						(int) ToRight.Fifth, 2.0f, 0.5f));
+					coroutines.Add(CreateHole(HoleType.NormalHole, 1.0f, 2.0f,
+						(int) Row.Second, (int) Column.Left));
 					break;
 				default:
 					throw new NotImplementedException();
@@ -65,7 +65,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
 		}
 
 		// 指定した行(or列)の端から一定の時間間隔(interval)で弾丸を作成するメソッド
-		private IEnumerator SetCartridge(CartridgeType cartridgeType, CartridgeDirection direction, int line,
+		private IEnumerator CreateCartridge(CartridgeType cartridgeType, CartridgeDirection direction, int line,
 			float appearanceTime, float interval)
 		{
 			var currentTime = Time.time;
@@ -152,7 +152,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
 		}
 
 		// 指定したパネルに一定の時間間隔(interval)で撃ち抜く銃弾を作成するメソッド
-		private IEnumerator SetHole(HoleType holeType, float appearanceTime, float interval, int row = 0,
+		private IEnumerator CreateHole(HoleType holeType, float appearanceTime, float interval, int row = 0,
 			int column = 0)
 		{
 			var currentTime = Time.time;

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/BulletGenerator.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/BulletGenerator.cs
@@ -98,9 +98,8 @@ namespace Project.Scripts.GamePlayScene.Bullet
 				var warningScript = warning.GetComponent<CartridgeWarningController>();
 				var bulletMotionVector = warningScript.Initialize(direction, line);
 
-				StartCoroutine(warningScript.Delete());
-				StartCoroutine(CreateCartridge(cartridgeType, direction, line, bulletMotionVector, tempBulletId,
-					appearanceTime + interval * (sum - 1)));
+				StartCoroutine(CreateCartridge(warning, cartridgeType, direction, line, bulletMotionVector,
+					tempBulletId));
 
 				try
 				{
@@ -118,11 +117,13 @@ namespace Project.Scripts.GamePlayScene.Bullet
 			}
 		}
 
-		private IEnumerator CreateCartridge(CartridgeType cartridgeType, CartridgeDirection direction, int line,
-			Vector2 motionVector, short cartridgeId, float time)
+		private IEnumerator CreateCartridge(GameObject warning, CartridgeType cartridgeType,
+			CartridgeDirection direction,
+			int line,
+			Vector2 motionVector, short cartridgeId)
 		{
-			var currentTime = Time.time;
-			yield return new WaitForSeconds(time - (currentTime - startTime));
+			yield return new WaitForSeconds(BulletWarningController.WARNING_DISPLAYED_TIME);
+			Destroy(warning);
 
 			if (gamePlayDirector.state == GamePlayDirector.GameState.Playing)
 			{
@@ -175,9 +176,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
 				warningScript.Initialize(row, column);
 
 				// delete the bullet warning
-				StartCoroutine(warningScript.Delete());
-				StartCoroutine(CreateHole(holeType, row, column, warning.transform.position, tempBulletId,
-					appearanceTime + interval * (sum - 1)));
+				StartCoroutine(CreateHole(warning, holeType, row, column, warning.transform.position, tempBulletId));
 
 				try
 				{
@@ -195,11 +194,12 @@ namespace Project.Scripts.GamePlayScene.Bullet
 			}
 		}
 
-		private IEnumerator CreateHole(HoleType holeType, int row, int column, Vector3 holeWarningPosition,
-			short holeId, float time)
+		private IEnumerator CreateHole(GameObject warning, HoleType holeType, int row, int column,
+			Vector3 holeWarningPosition,
+			short holeId)
 		{
-			var currentTime = Time.time;
-			yield return new WaitForSeconds(time - (currentTime - startTime));
+			yield return new WaitForSeconds(BulletWarningController.WARNING_DISPLAYED_TIME);
+			Destroy(warning);
 
 			if (gamePlayDirector.state == GamePlayDirector.GameState.Playing)
 			{

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/BulletGenerator.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/BulletGenerator.cs
@@ -81,28 +81,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
 			while (true)
 			{
 				sum++;
-				var tempBulletId = bulletId;
-
-				// 作成するcartidgeの種類で分岐
-				GameObject warning;
-				switch (cartridgeType)
-				{
-					case CartridgeType.NormalCartridge:
-						warning = Instantiate(normalCartridgeWarningPrefab);
-						break;
-					default:
-						throw new NotImplementedException();
-				}
-
-				// 同レイヤーのオブジェクトの描画順序の制御
-				warning.GetComponent<Renderer>().sortingOrder = tempBulletId;
-
-				// warningの位置・大きさ等の設定
-				var warningScript = warning.GetComponent<CartridgeWarningController>();
-				var bulletMotionVector = warningScript.Initialize(direction, line);
-				// warningの表示が終わる時刻を待ち、cartidgeを作成する
-				StartCoroutine(CreateCartridge(warning, cartridgeType, direction, line, bulletMotionVector,
-					tempBulletId));
+				StartCoroutine(CreateOneCartridge(cartridgeType, direction, line, bulletId));
 
 				// 作成する銃弾の個数の上限チェック
 				try
@@ -122,9 +101,27 @@ namespace Project.Scripts.GamePlayScene.Bullet
 		}
 
 		// warningの表示が終わる時刻を待ち、cartridgeを作成するメソッド
-		private IEnumerator CreateCartridge(GameObject warning, CartridgeType cartridgeType,
-			CartridgeDirection direction, int line, Vector2 motionVector, short cartridgeId)
+		private IEnumerator CreateOneCartridge(CartridgeType cartridgeType, CartridgeDirection direction, int line,
+			short cartridgeId)
 		{
+			// 作成するcartidgeの種類で分岐
+			GameObject warning;
+			switch (cartridgeType)
+			{
+				case CartridgeType.NormalCartridge:
+					warning = Instantiate(normalCartridgeWarningPrefab);
+					break;
+				default:
+					throw new NotImplementedException();
+			}
+
+			// 同レイヤーのオブジェクトの描画順序の制御
+			warning.GetComponent<Renderer>().sortingOrder = cartridgeId;
+
+			// warningの位置・大きさ等の設定
+			var warningScript = warning.GetComponent<CartridgeWarningController>();
+			var bulletMotionVector = warningScript.Initialize(direction, line);
+
 			// 警告の表示時間だけ待つ
 			yield return new WaitForSeconds(BulletWarningController.WARNING_DISPLAYED_TIME);
 			// 警告を削除する
@@ -145,7 +142,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
 
 				// 変数の初期設定
 				var cartridgeScript = cartridge.GetComponent<CartridgeController>();
-				cartridgeScript.Initialize(direction, line, motionVector);
+				cartridgeScript.Initialize(direction, line, bulletMotionVector);
 				// 同レイヤーのオブジェクトの描画順序の制御
 				cartridge.GetComponent<Renderer>().sortingOrder = cartridgeId;
 			}
@@ -164,24 +161,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
 			while (true)
 			{
 				sum++;
-				var tempBulletId = bulletId;
-
-				GameObject warning;
-				switch (holeType)
-				{
-					case HoleType.NormalHole:
-						warning = Instantiate(normalHoleWarningPrefab);
-						break;
-					default:
-						throw new NotImplementedException();
-				}
-
-				warning.GetComponent<Renderer>().sortingOrder = tempBulletId;
-
-				var warningScript = warning.GetComponent<HoleWarningController>();
-				warningScript.Initialize(row, column);
-
-				StartCoroutine(CreateHole(warning, holeType, row, column, warning.transform.position, tempBulletId));
+				StartCoroutine(CreateOneHole(holeType, row, column, bulletId));
 
 				try
 				{
@@ -199,9 +179,23 @@ namespace Project.Scripts.GamePlayScene.Bullet
 		}
 
 		// warningの表示が終わる時刻を待ち、holeを作成するメソッド
-		private IEnumerator CreateHole(GameObject warning, HoleType holeType, int row, int column,
-			Vector3 holeWarningPosition, short holeId)
+		private IEnumerator CreateOneHole(HoleType holeType, int row, int column, short holeId)
 		{
+			GameObject warning;
+			switch (holeType)
+			{
+				case HoleType.NormalHole:
+					warning = Instantiate(normalHoleWarningPrefab);
+					break;
+				default:
+					throw new NotImplementedException();
+			}
+
+			warning.GetComponent<Renderer>().sortingOrder = holeId;
+
+			var warningScript = warning.GetComponent<HoleWarningController>();
+			warningScript.Initialize(row, column);
+
 			yield return new WaitForSeconds(BulletWarningController.WARNING_DISPLAYED_TIME);
 			Destroy(warning);
 
@@ -218,7 +212,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
 				}
 
 				var holeScript = hole.GetComponent<HoleController>();
-				holeScript.Initialize(row, column, holeWarningPosition);
+				holeScript.Initialize(row, column, warning.transform.position);
 
 				hole.GetComponent<Renderer>().sortingOrder = holeId;
 				StartCoroutine(holeScript.Delete());

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/BulletGenerator.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/BulletGenerator.cs
@@ -9,6 +9,11 @@ namespace Project.Scripts.GamePlayScene.Bullet
 {
 	public class BulletGenerator : MonoBehaviour
 	{
+		// 生成された銃弾のID(sortingOrder)
+		private short bulletId = -32768;
+
+		private List<IEnumerator> coroutines;
+
 		private GamePlayDirector gamePlayDirector;
 
 		// 銃弾および警告のprefab
@@ -19,11 +24,6 @@ namespace Project.Scripts.GamePlayScene.Bullet
 
 		// Generatorが作成された時刻
 		public float startTime;
-
-		// 生成された銃弾のID(sortingOrder)
-		private short bulletId = -32768;
-
-		private List<IEnumerator> coroutines;
 
 		private void OnEnable()
 		{
@@ -192,7 +192,6 @@ namespace Project.Scripts.GamePlayScene.Bullet
 					gamePlayDirector.Dispatch(GamePlayDirector.GameState.Failure);
 				}
 
-				// 一定時間(interval)待つ
 				currentTime = Time.time;
 				yield return new WaitForSeconds(appearanceTime - BulletWarningController.WARNING_DISPLAYED_TIME +
 				                                interval * sum - (currentTime - startTime));

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/CartridgeController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/CartridgeController.cs
@@ -27,7 +27,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
 			gameObject.GetComponent<Rigidbody2D>().gravityScale = 0f;
 		}
 
-		public abstract void Initialize(CartridgeDirection direction, int line);
+		public abstract void Initialize(CartridgeDirection direction, int line, Vector2 motionVector);
 
 		protected void Update()
 		{
@@ -55,23 +55,19 @@ namespace Project.Scripts.GamePlayScene.Bullet
 					transform.position = new Vector2((WindowSize.WIDTH + CartridgeSize.WIDTH * LOCAL_SCALE) / 2,
 						WindowSize.HEIGHT * 0.5f - (TileSize.MARGIN_TOP + TileSize.HEIGHT * 0.5f) -
 						TileSize.HEIGHT * (line - 1));
-					motionVector = Vector2.left;
 					break;
 				case CartridgeDirection.ToRight:
 					transform.position = new Vector2(-(WindowSize.WIDTH + CartridgeSize.WIDTH * LOCAL_SCALE) / 2,
 						WindowSize.HEIGHT * 0.5f - (TileSize.MARGIN_TOP + TileSize.HEIGHT * 0.5f) -
 						TileSize.HEIGHT * (line - 1));
-					motionVector = Vector2.right;
 					break;
 				case CartridgeDirection.ToUp:
 					transform.position = new Vector2(TileSize.WIDTH * (line - 2),
 						-(WindowSize.HEIGHT + CartridgeSize.WIDTH * LOCAL_SCALE) / 2);
-					motionVector = Vector2.up;
 					break;
 				case CartridgeDirection.ToBottom:
 					transform.position = new Vector2(TileSize.WIDTH * (line - 2),
 						(WindowSize.HEIGHT + CartridgeSize.WIDTH * LOCAL_SCALE) / 2);
-					motionVector = Vector2.down;
 					break;
 				default:
 					throw new NotImplementedException();

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/HoleController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/HoleController.cs
@@ -20,6 +20,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
 		{
 		}
 
+		// 当たり判定(holeの表示場所に、tileがあるかどうかを確認する)
 		public IEnumerator Delete()
 		{
 			var gamePlayDirector = FindObjectOfType<GamePlayDirector>();

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/HoleController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/HoleController.cs
@@ -5,30 +5,24 @@ namespace Project.Scripts.GamePlayScene.Bullet
 {
 	public abstract class HoleController : BulletController
 	{
-		private GamePlayDirector gamePlayDirector;
 		private int row;
 		private int column;
 
-		private void Start()
-		{
-			gamePlayDirector = FindObjectOfType<GamePlayDirector>();
-			StartCoroutine(Delete());
-		}
-
 		// コンストラクタがわりのメソッド
-		public virtual void Initialize(int row, int column)
+		public void Initialize(int row, int column, Vector3 holeWarningPosition)
 		{
 			this.row = row;
 			this.column = column;
-			gameObject.SetActive(false);
+			transform.position = holeWarningPosition;
 		}
 
 		protected override void OnFail()
 		{
 		}
 
-		private IEnumerator Delete()
+		public IEnumerator Delete()
 		{
+			var gamePlayDirector = FindObjectOfType<GamePlayDirector>();
 			var tile = GameObject.Find("Tile" + ((row - 1) * 3 + column));
 			// check whether panel exists on the tile
 			if (tile.transform.childCount != 0)

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/NormalCartridgeController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/NormalCartridgeController.cs
@@ -1,12 +1,14 @@
 ﻿using Project.Scripts.Utils.Definitions;
+using UnityEngine;
 
 namespace Project.Scripts.GamePlayScene.Bullet
 {
 	public class NormalCartridgeController : CartridgeController
 	{
 		// コンストラクタがわりのメソッド
-		public override void Initialize(CartridgeDirection direction, int line)
+		public override void Initialize(CartridgeDirection direction, int line, Vector2 motionVector)
 		{
+			this.motionVector = motionVector;
 			SetInitialPosition(direction, line);
 		}
 	}

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/NormalHoleController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/NormalHoleController.cs
@@ -11,13 +11,5 @@ namespace Project.Scripts.GamePlayScene.Bullet
 			transform.localScale = new Vector2(HoleSize.WIDTH / originalWidth, HoleSize.HEIGHT / originalHeight) *
 			                       LOCAL_SCALE;
 		}
-
-		public override void Initialize(int row, int column)
-		{
-			base.Initialize(row, column);
-			const float topTilePositionY = WindowSize.HEIGHT * 0.5f - (TileSize.MARGIN_TOP + TileSize.HEIGHT * 0.5f);
-			transform.position =
-				new Vector2(TileSize.WIDTH * (column - 2), topTilePositionY - TileSize.HEIGHT * (row - 1));
-		}
 	}
 }

--- a/Assets/Project/Scripts/GamePlayScene/BulletWarning/BulletWarningController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/BulletWarning/BulletWarningController.cs
@@ -1,6 +1,4 @@
 ﻿using UnityEngine;
-using System;
-using System.Collections;
 
 namespace Project.Scripts.GamePlayScene.BulletWarning
 {

--- a/Assets/Project/Scripts/GamePlayScene/BulletWarning/BulletWarningController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/BulletWarning/BulletWarningController.cs
@@ -41,11 +41,5 @@ namespace Project.Scripts.GamePlayScene.BulletWarning
 		{
 			Destroy(gameObject);
 		}
-
-		public IEnumerator Delete()
-		{
-			yield return new WaitForSeconds(WARNING_DISPLAYED_TIME);
-			Destroy(gameObject);
-		}
 	}
 }

--- a/Assets/Project/Scripts/GamePlayScene/BulletWarning/BulletWarningController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/BulletWarning/BulletWarningController.cs
@@ -1,4 +1,5 @@
 ﻿using UnityEngine;
+using System;
 
 namespace Project.Scripts.GamePlayScene.BulletWarning
 {
@@ -6,6 +7,8 @@ namespace Project.Scripts.GamePlayScene.BulletWarning
 	{
 		// 警告画像の表示時間
 		public const float WARNING_DISPLAYED_TIME = 1.0f;
+
+		[NonSerialized] public const float LOCAL_SCALE = 1.0f;
 
 		// 元画像のサイズ
 		protected float originalHeight;

--- a/Assets/Project/Scripts/GamePlayScene/BulletWarning/BulletWarningController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/BulletWarning/BulletWarningController.cs
@@ -1,5 +1,6 @@
 ﻿using UnityEngine;
 using System;
+using System.Collections;
 
 namespace Project.Scripts.GamePlayScene.BulletWarning
 {
@@ -40,6 +41,12 @@ namespace Project.Scripts.GamePlayScene.BulletWarning
 
 		private void OnFail()
 		{
+			Destroy(gameObject);
+		}
+
+		public IEnumerator Delete()
+		{
+			yield return new WaitForSeconds(WARNING_DISPLAYED_TIME);
 			Destroy(gameObject);
 		}
 	}

--- a/Assets/Project/Scripts/GamePlayScene/BulletWarning/BulletWarningController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/BulletWarning/BulletWarningController.cs
@@ -9,8 +9,6 @@ namespace Project.Scripts.GamePlayScene.BulletWarning
 		// 警告画像の表示時間
 		public const float WARNING_DISPLAYED_TIME = 1.0f;
 
-		[NonSerialized] public const float LOCAL_SCALE = 1.0f;
-
 		// 元画像のサイズ
 		protected float originalHeight;
 		protected float originalWidth;

--- a/Assets/Project/Scripts/GamePlayScene/BulletWarning/CartridgeWarningController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/BulletWarning/CartridgeWarningController.cs
@@ -1,26 +1,17 @@
 ﻿using System.Collections;
 using Project.Scripts.GamePlayScene.Bullet;
+using Project.Scripts.Utils.Definitions;
 using UnityEngine;
 
 namespace Project.Scripts.GamePlayScene.BulletWarning
 {
 	public abstract class CartridgeWarningController : BulletWarningController
 	{
-		public abstract void Initialize(Vector2 bulletPosition, Vector2 bulletMotionVector, float bulletLocalScale,
-			float bulletWidth, float bulletHeight);
+		public abstract Vector2 Initialize(CartridgeDirection direction, int line);
 
-		public void DeleteWarning(GameObject bullet)
-		{
-			var tempSpeed = bullet.GetComponent<CartridgeController>().speed;
-			// the bullet does not move while warning is existing
-			bullet.GetComponent<CartridgeController>().speed = 0.0f;
-			StartCoroutine(Delete(bullet, tempSpeed));
-		}
-
-		private IEnumerator Delete(GameObject bullet, float speed)
+		public IEnumerator DeleteWarning()
 		{
 			yield return new WaitForSeconds(WARNING_DISPLAYED_TIME);
-			bullet.GetComponent<CartridgeController>().speed = speed;
 			Destroy(gameObject);
 		}
 	}

--- a/Assets/Project/Scripts/GamePlayScene/BulletWarning/CartridgeWarningController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/BulletWarning/CartridgeWarningController.cs
@@ -8,11 +8,5 @@ namespace Project.Scripts.GamePlayScene.BulletWarning
 	public abstract class CartridgeWarningController : BulletWarningController
 	{
 		public abstract Vector2 Initialize(CartridgeDirection direction, int line);
-
-		public IEnumerator DeleteWarning()
-		{
-			yield return new WaitForSeconds(WARNING_DISPLAYED_TIME);
-			Destroy(gameObject);
-		}
 	}
 }

--- a/Assets/Project/Scripts/GamePlayScene/BulletWarning/CartridgeWarningController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/BulletWarning/CartridgeWarningController.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections;
-using Project.Scripts.GamePlayScene.Bullet;
-using Project.Scripts.Utils.Definitions;
+﻿using Project.Scripts.Utils.Definitions;
 using UnityEngine;
 
 namespace Project.Scripts.GamePlayScene.BulletWarning

--- a/Assets/Project/Scripts/GamePlayScene/BulletWarning/HoleWarningController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/BulletWarning/HoleWarningController.cs
@@ -6,17 +6,5 @@ namespace Project.Scripts.GamePlayScene.BulletWarning
 	public abstract class HoleWarningController : BulletWarningController
 	{
 		public abstract void Initialize(int row, int column);
-
-		public void DeleteWarning(GameObject hole)
-		{
-			StartCoroutine(Delete(hole));
-		}
-
-		private IEnumerator Delete(GameObject hole)
-		{
-			yield return new WaitForSeconds(WARNING_DISPLAYED_TIME);
-			Destroy(gameObject);
-			hole.SetActive(true);
-		}
 	}
 }

--- a/Assets/Project/Scripts/GamePlayScene/BulletWarning/HoleWarningController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/BulletWarning/HoleWarningController.cs
@@ -1,7 +1,4 @@
-﻿using System.Collections;
-using UnityEngine;
-
-namespace Project.Scripts.GamePlayScene.BulletWarning
+﻿namespace Project.Scripts.GamePlayScene.BulletWarning
 {
 	public abstract class HoleWarningController : BulletWarningController
 	{

--- a/Assets/Project/Scripts/GamePlayScene/BulletWarning/NormalCartridgeWarningController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/BulletWarning/NormalCartridgeWarningController.cs
@@ -1,5 +1,6 @@
 ﻿using Project.Scripts.Utils.Definitions;
 using UnityEngine;
+using System;
 
 namespace Project.Scripts.GamePlayScene.BulletWarning
 {
@@ -12,11 +13,42 @@ namespace Project.Scripts.GamePlayScene.BulletWarning
 				new Vector2(CartridgeWarningSize.WIDTH / originalWidth, CartridgeWarningSize.HEIGHT / originalHeight);
 		}
 
-		public override void Initialize(Vector2 bulletPosition, Vector2 bulletMotionVector, float bulletLocalScale,
-			float bulletWidth, float bulletHeight)
+		public override Vector2 Initialize(CartridgeDirection direction, int line)
 		{
-			transform.position = bulletPosition + Vector2.Scale(bulletMotionVector,
-				                     new Vector2(CartridgeWarningSize.POSITION_X, CartridgeWarningSize.POSITION_Y));
+			Vector2 bulletMotionVector;
+			Vector2 warningPosition;
+			switch (direction)
+			{
+				case CartridgeDirection.ToLeft:
+					warningPosition = new Vector2(WindowSize.WIDTH / 2,
+						WindowSize.HEIGHT * 0.5f - (TileSize.MARGIN_TOP + TileSize.HEIGHT * 0.5f) -
+						TileSize.HEIGHT * (line - 1));
+					bulletMotionVector = Vector2.left;
+					break;
+				case CartridgeDirection.ToRight:
+					warningPosition = new Vector2(-WindowSize.WIDTH / 2,
+						WindowSize.HEIGHT * 0.5f - (TileSize.MARGIN_TOP + TileSize.HEIGHT * 0.5f) -
+						TileSize.HEIGHT * (line - 1));
+					bulletMotionVector = Vector2.right;
+					break;
+				case CartridgeDirection.ToUp:
+					warningPosition = new Vector2(TileSize.WIDTH * (line - 2),
+						-WindowSize.HEIGHT / 2);
+					bulletMotionVector = Vector2.up;
+					break;
+				case CartridgeDirection.ToBottom:
+					warningPosition = new Vector2(TileSize.WIDTH * (line - 2),
+						WindowSize.HEIGHT / 2);
+					bulletMotionVector = Vector2.down;
+					break;
+				default:
+					throw new NotImplementedException();
+			}
+
+			warningPosition = warningPosition + Vector2.Scale(bulletMotionVector,
+				                  new Vector2(CartridgeWarningSize.POSITION_X, CartridgeWarningSize.POSITION_Y)) / 2;
+			transform.position = warningPosition;
+			return bulletMotionVector;
 		}
 	}
 }

--- a/Assets/Project/Scripts/GamePlayScene/BulletWarning/NormalCartridgeWarningController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/BulletWarning/NormalCartridgeWarningController.cs
@@ -13,6 +13,8 @@ namespace Project.Scripts.GamePlayScene.BulletWarning
 				new Vector2(CartridgeWarningSize.WIDTH / originalWidth, CartridgeWarningSize.HEIGHT / originalHeight);
 		}
 
+		// 警告のpositionを計算する
+		// 銃弾の移動方向(bulletMotionVector)が副次的に計算されるので、その値を返す
 		public override Vector2 Initialize(CartridgeDirection direction, int line)
 		{
 			Vector2 bulletMotionVector;

--- a/Assets/Project/Scripts/GamePlayScene/BulletWarning/NormalHoleWarningController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/BulletWarning/NormalHoleWarningController.cs
@@ -12,6 +12,7 @@ namespace Project.Scripts.GamePlayScene.BulletWarning
 				new Vector2(HoleWarningSize.WIDTH / originalWidth, HoleWarningSize.HEIGHT / originalHeight);
 		}
 
+		// 警告のpositionを計算する
 		public override void Initialize(int row, int column)
 		{
 			const float topTilePositionY = WindowSize.HEIGHT * 0.5f - (TileSize.MARGIN_TOP + TileSize.HEIGHT * 0.5f);

--- a/Assets/Project/Scripts/MenuBarScene/MenuBarDirector.cs
+++ b/Assets/Project/Scripts/MenuBarScene/MenuBarDirector.cs
@@ -54,20 +54,14 @@ namespace Project.Scripts.MenuBarScene
 				ToggleValueChanged(stageSelectToggle);
 			});
 
-			recordToggle.GetComponent<Toggle>().onValueChanged.AddListener(delegate
-			{
-				ToggleValueChanged(recordToggle);
-			});
+			recordToggle.GetComponent<Toggle>().onValueChanged
+				.AddListener(delegate { ToggleValueChanged(recordToggle); });
 
-			tutorialToggle.GetComponent<Toggle>().onValueChanged.AddListener(delegate
-			{
-				ToggleValueChanged(tutorialToggle);
-			});
+			tutorialToggle.GetComponent<Toggle>().onValueChanged
+				.AddListener(delegate { ToggleValueChanged(tutorialToggle); });
 
-			configToggle.GetComponent<Toggle>().onValueChanged.AddListener(delegate
-			{
-				ToggleValueChanged(configToggle);
-			});
+			configToggle.GetComponent<Toggle>().onValueChanged
+				.AddListener(delegate { ToggleValueChanged(configToggle); });
 		}
 
 		private void ToggleValueChanged(GameObject toggle)


### PR DESCRIPTION
## 対象イシュー
https://app.mmth.pro/projects/18382/tasks#/show/210774

## 概要
以前までは警告と銃弾のインスタンスを同時に作成し、警告が消えるまで銃弾を非表示にしていた。
それを、警告の消えるタイミングの後に銃弾を表示するように変更した。

## 技術的な内容
以前の、銃弾と警告の組を連続して作成するcoroutineから、
警告を連続的に作成するcoroutineと、銃弾を1つだけ作成するcoroutineに分けて、
警告を連続的に作成するcoroutineの各ループで、銃弾を1つだけ作成するcoroutineを呼ぶ。

#### 追加(2019/03/10)
- 銃弾→警告の計算順序だったものを、警告→銃弾に変更
- 警告の表示、削除や銃弾の表示は`BulletGenerator.cs`に記述

## 詳しい説明
`BulletGenerator.cs`
- 概要の内容
- 警告の表示(1秒)後、銃弾を作成する時に、すでにゲームが終了していないかかどうかを確認する
`BulletWarning`ディレクトリ以下
- 警告のpositionの計算に、銃弾のpositionを用いていたが、今回、銃弾の作成よりも前に警告のpositionを計算する必要があるので、銃弾のpositionの計算に用いていた引数を受け取り、計算する記述を追加
- 表示時間を終えた警告の削除、銃弾の表示・非表示の管理などはcontrollerに記述せず、`BulletGenerator.cs`内に作成した新たなcoroutine内に記述
`Bullet`ディレクトリ以下
- 警告のpositionの計算で求める必要のあったいくつかの変数は、controller内で再計算せず、引数として受け取り、そのまま保存するように変更
