### PR TITLE
StageGeneratorの導入

### DIFF
--- a/Assets/Project/Scenes/GamePlayScene.unity
+++ b/Assets/Project/Scenes/GamePlayScene.unity
@@ -1072,7 +1072,7 @@ Transform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1755014452}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 264.16464, y: -8.997072, z: -16.939686}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}

--- a/Assets/Project/Scenes/GamePlayScene.unity
+++ b/Assets/Project/Scenes/GamePlayScene.unity
@@ -913,6 +913,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7fde76e837a3c4d0d837f5f8fc9a4460, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  state: 0
 --- !u!4 &1638029897
 Transform:
   m_ObjectHideFlags: 0
@@ -1048,6 +1049,46 @@ CanvasRenderer:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1659381245}
+--- !u!1 &1755014452
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1755014453}
+  - component: {fileID: 1755014454}
+  m_Layer: 0
+  m_Name: StageGenerator
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1755014453
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1755014452}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 264.16464, y: -8.997072, z: -16.939686}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1755014454
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1755014452}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7b89c7ce9e7854098bd0794a314a3140, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1797629528
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/BulletGenerator.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/BulletGenerator.cs
@@ -37,35 +37,17 @@ namespace Project.Scripts.GamePlayScene.Bullet
 			GamePlayDirector.OnFail -= OnFail;
 		}
 
-		public void CreateBullets(int stageId)
+		public void CreateBullets(List<IEnumerator> coroutines)
 		{
+			this.coroutines = coroutines;
 			gamePlayDirector = FindObjectOfType<GamePlayDirector>();
-			coroutines = new List<IEnumerator>();
 			startTime = Time.time;
-			switch (stageId)
-			{
-				case 1:
-					// coroutineのリスト
-					coroutines.Add(CreateCartridge(CartridgeType.NormalCartridge, CartridgeDirection.ToLeft,
-						(int) ToLeft.First, 1.0f, 1.0f));
-					coroutines.Add(CreateCartridge(CartridgeType.NormalCartridge, CartridgeDirection.ToRight,
-						(int) ToRight.Second, 2.0f, 4.0f));
-					break;
-				case 2:
-					coroutines.Add(CreateCartridge(CartridgeType.NormalCartridge, CartridgeDirection.ToRight,
-						(int) ToRight.Fifth, 2.0f, 0.5f));
-					coroutines.Add(CreateHole(HoleType.NormalHole, 1.0f, 2.0f,
-						(int) Row.Second, (int) Column.Left));
-					break;
-				default:
-					throw new NotImplementedException();
-			}
 
 			foreach (var coroutine in coroutines) StartCoroutine(coroutine);
 		}
 
 		// 指定した行(or列)の端から一定の時間間隔(interval)で弾丸を作成するメソッド
-		private IEnumerator CreateCartridge(CartridgeType cartridgeType, CartridgeDirection direction, int line,
+		public IEnumerator CreateCartridge(CartridgeType cartridgeType, CartridgeDirection direction, int line,
 			float appearanceTime, float interval)
 		{
 			var currentTime = Time.time;
@@ -149,7 +131,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
 		}
 
 		// 指定したパネルに一定の時間間隔(interval)で撃ち抜く銃弾を作成するメソッド
-		private IEnumerator CreateHole(HoleType holeType, float appearanceTime, float interval, int row = 0,
+		public IEnumerator CreateHole(HoleType holeType, float appearanceTime, float interval, int row = 0,
 			int column = 0)
 		{
 			var currentTime = Time.time;

--- a/Assets/Project/Scripts/GamePlayScene/GamePlayDirector.cs
+++ b/Assets/Project/Scripts/GamePlayScene/GamePlayDirector.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using System.Linq;
 using Project.Scripts.Utils.Definitions;
-using Project.Scripts.GamePlayScene.Bullet;
 using Project.Scripts.GamePlayScene.Panel;
-using Project.Scripts.GamePlayScene.Tile;
 using Project.Scripts.Utils.PlayerPrefsUtils;
 using UnityEngine;
 using UnityEngine.SceneManagement;
@@ -30,11 +28,7 @@ namespace Project.Scripts.GamePlayScene
 
 		public GameState state = GameState.Opening;
 
-		private GameObject tileGenerator;
-
-		private GameObject panelGenerator;
-
-		private GameObject bulletGenerator;
+		private GameObject stageGenerator;
 
 		private GameObject resultWindow;
 
@@ -54,9 +48,7 @@ namespace Project.Scripts.GamePlayScene
 		{
 			UnifyDisplay();
 
-			tileGenerator = GameObject.Find("TileGenerator");
-			panelGenerator = GameObject.Find("PanelGenerator");
-			bulletGenerator = GameObject.Find("BulletGenerator");
+			stageGenerator = GameObject.Find("StageGenerator");
 
 			resultWindow = GameObject.Find("ResultWindow");
 
@@ -65,7 +57,10 @@ namespace Project.Scripts.GamePlayScene
 			stageNumberText = GameObject.Find("StageNumberText");
 
 			SetAudioSource();
+		}
 
+		private void Start()
+		{
 			GameOpening();
 		}
 
@@ -160,12 +155,8 @@ namespace Project.Scripts.GamePlayScene
 			// 結果ウィンドウを非表示
 			resultWindow.SetActive(false);
 
-			// タイル作成スクリプトを起動
-			tileGenerator.GetComponent<TileGenerator>().CreateTiles(stageId);
-			// パネル作成スクリプトを起動
-			panelGenerator.GetComponent<PanelGenerator>().CreatePanels(stageId);
-			// 銃弾作成スクリプトを起動
-			bulletGenerator.GetComponent<BulletGenerator>().CreateBullets(stageId);
+			// 番号に合わせたステージの作成
+			stageGenerator.GetComponent<StageGenerator>().CreateStages(stageId);
 
 			// 状態を変更する
 			Dispatch(GameState.Playing);

--- a/Assets/Project/Scripts/GamePlayScene/Panel/PanelGenerator.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Panel/PanelGenerator.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿using System.Collections.Generic;
 using UnityEngine;
 
 namespace Project.Scripts.GamePlayScene.Panel
@@ -16,40 +16,27 @@ namespace Project.Scripts.GamePlayScene.Panel
 		public GameObject staticDummyPanelPrefab;
 		public GameObject dynamicDummyPanelPrefab;
 
+		private List<GameObject> numberPanelPrefabs;
+
+		private void Awake()
+		{
+			numberPanelPrefabs = new List<GameObject>
+			{
+				numberPanel1Prefab,
+				numberPanel2Prefab,
+				numberPanel3Prefab,
+				numberPanel4Prefab,
+				numberPanel4Prefab,
+				numberPanel5Prefab,
+				numberPanel6Prefab,
+				numberPanel7Prefab,
+				numberPanel8Prefab
+			};
+		}
+
 		public void CreateNumberPanel(int panelNumber, int initialTileNum, int finalTileNum)
 		{
-			GameObject panelPrefab;
-			switch (panelNumber)
-			{
-				case 1:
-					panelPrefab = numberPanel1Prefab;
-					break;
-				case 2:
-					panelPrefab = numberPanel2Prefab;
-					break;
-				case 3:
-					panelPrefab = numberPanel3Prefab;
-					break;
-				case 4:
-					panelPrefab = numberPanel4Prefab;
-					break;
-				case 5:
-					panelPrefab = numberPanel5Prefab;
-					break;
-				case 6:
-					panelPrefab = numberPanel6Prefab;
-					break;
-				case 7:
-					panelPrefab = numberPanel7Prefab;
-					break;
-				case 8:
-					panelPrefab = numberPanel8Prefab;
-					break;
-				default:
-					throw new NotImplementedException();
-			}
-
-			var panel = Instantiate(panelPrefab);
+			var panel = Instantiate(numberPanelPrefabs[panelNumber - 1]);
 			panel.GetComponent<NumberPanelController>().Initialize(initialTileNum, finalTileNum);
 		}
 

--- a/Assets/Project/Scripts/GamePlayScene/Panel/PanelGenerator.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Panel/PanelGenerator.cs
@@ -16,53 +16,52 @@ namespace Project.Scripts.GamePlayScene.Panel
 		public GameObject staticDummyPanelPrefab;
 		public GameObject dynamicDummyPanelPrefab;
 
-		// 現段階では8枚のパネル群
-		public void CreatePanels(int stageId)
+		public void CreateNumberPanel(int panelNumber, int initialTileNum, int finalTileNum)
 		{
-			switch (stageId)
+			GameObject panelPrefab;
+			switch (panelNumber)
 			{
 				case 1:
-					CreateDynamicDummyPanel(initialTileNum: 3, panelPrefab: dynamicDummyPanelPrefab);
-					CreateNumberPanel(initialTileNum: 4, finalTileNum: 4, panelPrefab: numberPanel1Prefab);
-					CreateNumberPanel(initialTileNum: 5, finalTileNum: 5, panelPrefab: numberPanel2Prefab);
-					CreateNumberPanel(initialTileNum: 6, finalTileNum: 6, panelPrefab: numberPanel3Prefab);
-					CreateNumberPanel(initialTileNum: 7, finalTileNum: 7, panelPrefab: numberPanel4Prefab);
-					CreateNumberPanel(initialTileNum: 8, finalTileNum: 8, panelPrefab: numberPanel5Prefab);
-					CreateNumberPanel(initialTileNum: 9, finalTileNum: 9, panelPrefab: numberPanel6Prefab);
-					CreateNumberPanel(initialTileNum: 10, finalTileNum: 10, panelPrefab: numberPanel7Prefab);
-					CreateNumberPanel(initialTileNum: 14, finalTileNum: 11, panelPrefab: numberPanel8Prefab);
-					CreateStaticDummyPanel(initialTileNum: 15, panelPrefab: staticDummyPanelPrefab);
+					panelPrefab = numberPanel1Prefab;
 					break;
 				case 2:
-					CreateNumberPanel(initialTileNum: 1, finalTileNum: 4, panelPrefab: numberPanel1Prefab);
-					CreateNumberPanel(initialTileNum: 3, finalTileNum: 5, panelPrefab: numberPanel2Prefab);
-					CreateNumberPanel(initialTileNum: 5, finalTileNum: 6, panelPrefab: numberPanel3Prefab);
-					CreateNumberPanel(initialTileNum: 6, finalTileNum: 7, panelPrefab: numberPanel4Prefab);
-					CreateNumberPanel(initialTileNum: 8, finalTileNum: 8, panelPrefab: numberPanel5Prefab);
-					CreateNumberPanel(initialTileNum: 11, finalTileNum: 9, panelPrefab: numberPanel6Prefab);
-					CreateNumberPanel(initialTileNum: 13, finalTileNum: 10, panelPrefab: numberPanel7Prefab);
-					CreateNumberPanel(initialTileNum: 15, finalTileNum: 11, panelPrefab: numberPanel8Prefab);
+					panelPrefab = numberPanel2Prefab;
+					break;
+				case 3:
+					panelPrefab = numberPanel3Prefab;
+					break;
+				case 4:
+					panelPrefab = numberPanel4Prefab;
+					break;
+				case 5:
+					panelPrefab = numberPanel5Prefab;
+					break;
+				case 6:
+					panelPrefab = numberPanel6Prefab;
+					break;
+				case 7:
+					panelPrefab = numberPanel7Prefab;
+					break;
+				case 8:
+					panelPrefab = numberPanel8Prefab;
 					break;
 				default:
 					throw new NotImplementedException();
 			}
-		}
 
-		private static void CreateNumberPanel(int initialTileNum, int finalTileNum, GameObject panelPrefab)
-		{
 			var panel = Instantiate(panelPrefab);
 			panel.GetComponent<NumberPanelController>().Initialize(initialTileNum, finalTileNum);
 		}
 
-		private static void CreateStaticDummyPanel(int initialTileNum, GameObject panelPrefab)
+		public void CreateStaticDummyPanel(int initialTileNum)
 		{
-			var panel = Instantiate(panelPrefab);
+			var panel = Instantiate(staticDummyPanelPrefab);
 			panel.GetComponent<StaticPanelController>().Initialize(initialTileNum);
 		}
 
-		private static void CreateDynamicDummyPanel(int initialTileNum, GameObject panelPrefab)
+		public void CreateDynamicDummyPanel(int initialTileNum)
 		{
-			var panel = Instantiate(panelPrefab);
+			var panel = Instantiate(dynamicDummyPanelPrefab);
 			panel.GetComponent<DynamicPanelController>().Initialize(initialTileNum);
 		}
 	}

--- a/Assets/Project/Scripts/GamePlayScene/StageGenerator.cs
+++ b/Assets/Project/Scripts/GamePlayScene/StageGenerator.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using UnityEngine;
+using System.Collections;
+using System.Collections.Generic;
+using Project.Scripts.GamePlayScene.Bullet;
+using Project.Scripts.GamePlayScene.Panel;
+using Project.Scripts.GamePlayScene.Tile;
+using Project.Scripts.Utils.Definitions;
+
+
+namespace Project.Scripts.GamePlayScene
+{
+	public class StageGenerator : MonoBehaviour
+	{
+		private TileGenerator tileGenerator;
+
+		private PanelGenerator panelGenerator;
+
+		private BulletGenerator bulletGenerator;
+
+		private void Awake()
+		{
+			tileGenerator = GameObject.Find("TileGenerator").GetComponent<TileGenerator>();
+			panelGenerator = GameObject.Find("PanelGenerator").GetComponent<PanelGenerator>();
+			bulletGenerator = GameObject.Find("BulletGenerator").GetComponent<BulletGenerator>();
+		}
+
+		public void CreateStages(int stageId)
+		{
+			// タイル作成
+			tileGenerator.CreateTiles();
+
+			List<IEnumerator> coroutines = new List<IEnumerator>();
+
+			switch (stageId)
+			{
+				case 1:
+					// 銃弾実体生成
+					coroutines.Add(bulletGenerator.CreateCartridge(CartridgeType.NormalCartridge,
+						CartridgeDirection.ToLeft,
+						(int) ToLeft.First, 1.0f, 1.0f));
+					coroutines.Add(bulletGenerator.CreateCartridge(CartridgeType.NormalCartridge,
+						CartridgeDirection.ToRight,
+						(int) ToRight.Second, 2.0f, 4.0f));
+					// パネル作成
+					panelGenerator.CreateDynamicDummyPanel(initialTileNum: 3);
+					panelGenerator.CreateNumberPanel(panelNumber: 1, initialTileNum: 4, finalTileNum: 4);
+					panelGenerator.CreateNumberPanel(panelNumber: 2, initialTileNum: 5, finalTileNum: 5);
+					panelGenerator.CreateNumberPanel(panelNumber: 3, initialTileNum: 6, finalTileNum: 6);
+					panelGenerator.CreateNumberPanel(panelNumber: 4, initialTileNum: 7, finalTileNum: 7);
+					panelGenerator.CreateNumberPanel(panelNumber: 5, initialTileNum: 8, finalTileNum: 8);
+					panelGenerator.CreateNumberPanel(panelNumber: 6, initialTileNum: 9, finalTileNum: 9);
+					panelGenerator.CreateNumberPanel(panelNumber: 7, initialTileNum: 10, finalTileNum: 10);
+					panelGenerator.CreateNumberPanel(panelNumber: 8, initialTileNum: 14, finalTileNum: 11);
+					panelGenerator.CreateStaticDummyPanel(initialTileNum: 15);
+					break;
+				case 2:
+					// 銃弾実体生成
+					coroutines.Add(bulletGenerator.CreateCartridge(CartridgeType.NormalCartridge,
+						CartridgeDirection.ToRight,
+						(int) ToRight.Fifth, 2.0f, 0.5f));
+					coroutines.Add(bulletGenerator.CreateHole(HoleType.NormalHole, 1.0f, 2.0f,
+						(int) Row.Second, (int) Column.Left));
+					// パネル作成
+					panelGenerator.CreateNumberPanel(panelNumber: 1, initialTileNum: 1, finalTileNum: 4);
+					panelGenerator.CreateNumberPanel(panelNumber: 2, initialTileNum: 3, finalTileNum: 5);
+					panelGenerator.CreateNumberPanel(panelNumber: 3, initialTileNum: 5, finalTileNum: 6);
+					panelGenerator.CreateNumberPanel(panelNumber: 4, initialTileNum: 6, finalTileNum: 7);
+					panelGenerator.CreateNumberPanel(panelNumber: 5, initialTileNum: 8, finalTileNum: 8);
+					panelGenerator.CreateNumberPanel(panelNumber: 6, initialTileNum: 11, finalTileNum: 9);
+					panelGenerator.CreateNumberPanel(panelNumber: 7, initialTileNum: 13, finalTileNum: 10);
+					panelGenerator.CreateNumberPanel(panelNumber: 8, initialTileNum: 15, finalTileNum: 11);
+					break;
+				default:
+					throw new NotImplementedException();
+			}
+
+			// 銃弾の一括作成
+			bulletGenerator.CreateBullets(coroutines);
+		}
+	}
+}

--- a/Assets/Project/Scripts/GamePlayScene/StageGenerator.cs.meta
+++ b/Assets/Project/Scripts/GamePlayScene/StageGenerator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7b89c7ce9e7854098bd0794a314a3140
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/Scripts/GamePlayScene/Tile/TileGenerator.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Tile/TileGenerator.cs
@@ -9,7 +9,7 @@ namespace Project.Scripts.GamePlayScene.Tile
 
 		// 現段階では5行3列のタイル群
 		// 現段階ではステージ番号に依存しない
-		public void CreateTiles(int stageId)
+		public void CreateTiles()
 		{
 			// 最上タイルのy座標
 			const float topTilePositionY = WindowSize.HEIGHT * 0.5f - (TileSize.MARGIN_TOP + TileSize.HEIGHT * 0.5f);


### PR DESCRIPTION
## 対象イシュー
https://app.mmth.pro/projects/18382/tasks#/show/212391

## 概要
以下のGeneratorの一部を統合し，ステージ作成に特化した，`StageGenerator`を作成
- `TileGenerator`
- `PanelGenerator`
- `BulletGenerator`

## 技術的な内容
- `GamePlayDirector`において，`GameOpening()`を`Awake()`のなかで呼んでしまうと，初期化不良により参照エラーが起きてしまうため，`Start()`へ移動．
- 動作を変えずに，Generatorをまとめるために，いくつかのシグニチャを変更．

## 今後の課題
- `StageGenerator`にまとめることによって，使い勝手は上がったが，関数を呼び出す際のシグニチャなどをうまく整備して，より使いやすくすることが可能だと思われる．

