### PR TITLE
音量を調整できる

### DIFF
--- a/Assets/Project/Scenes/ConfigScene.unity
+++ b/Assets/Project/Scenes/ConfigScene.unity
@@ -4049,7 +4049,7 @@ MonoBehaviour:
   m_MinValue: 0
   m_MaxValue: 1
   m_WholeNumbers: 0
-  m_Value: 0
+  m_Value: 0.5
   m_OnValueChanged:
     m_PersistentCalls:
       m_Calls: []

--- a/Assets/Project/Scenes/ConfigScene.unity
+++ b/Assets/Project/Scenes/ConfigScene.unity
@@ -1597,10 +1597,10 @@ RectTransform:
   - {fileID: 125786992}
   - {fileID: 1994264580}
   m_Father: {fileID: 1600300740}
-  m_RootOrder: 2
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0.775}
-  m_AnchorMax: {x: 1, y: 0.825}
+  m_AnchorMin: {x: 0, y: 0.85}
+  m_AnchorMax: {x: 1, y: 0.9}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
@@ -3402,10 +3402,10 @@ RectTransform:
   - {fileID: 1112527333}
   - {fileID: 11511954}
   m_Father: {fileID: 1600300740}
-  m_RootOrder: 1
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0.85}
-  m_AnchorMax: {x: 1, y: 0.9}
+  m_AnchorMin: {x: 0, y: 0.775}
+  m_AnchorMax: {x: 1, y: 0.825}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
@@ -3468,8 +3468,8 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 437239861}
-  - {fileID: 1532375888}
   - {fileID: 513860934}
+  - {fileID: 1532375888}
   - {fileID: 102037232}
   - {fileID: 1237425347}
   - {fileID: 17352300}

--- a/Assets/Project/Scenes/ConfigScene.unity
+++ b/Assets/Project/Scenes/ConfigScene.unity
@@ -3383,7 +3383,7 @@ GameObject:
   - component: {fileID: 1532375890}
   - component: {fileID: 1532375889}
   m_Layer: 5
-  m_Name: Notification
+  m_Name: Vibration
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0

--- a/Assets/Project/Scenes/ConfigScene.unity
+++ b/Assets/Project/Scenes/ConfigScene.unity
@@ -3979,6 +3979,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1994264580}
   - component: {fileID: 1994264581}
+  - component: {fileID: 1994264582}
   m_Layer: 5
   m_Name: Slider
   m_TagString: Untagged
@@ -4055,6 +4056,17 @@ MonoBehaviour:
       m_Calls: []
     m_TypeName: UnityEngine.UI.Slider+SliderEvent, UnityEngine.UI, Version=1.0.0.0,
       Culture=neutral, PublicKeyToken=null
+--- !u!114 &1994264582
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1994264579}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cc480e3a20fa044fdbed3d7df95ec7ed, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &2112120526
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Project/Scripts/ConfigScene.meta
+++ b/Assets/Project/Scripts/ConfigScene.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9de1c9e71ce974d9eafcd980fdf6a8e1
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/Scripts/ConfigScene/VolumeController.cs
+++ b/Assets/Project/Scripts/ConfigScene/VolumeController.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class VolumeController : MonoBehaviour {
+
+	// Use this for initialization
+	void Start () {
+		
+	}
+	
+	// Update is called once per frame
+	void Update () {
+		
+	}
+}

--- a/Assets/Project/Scripts/ConfigScene/VolumeController.cs
+++ b/Assets/Project/Scripts/ConfigScene/VolumeController.cs
@@ -12,7 +12,7 @@ namespace Project.Scripts.ConfigScene
 		{
 			volumeSlider = GetComponent<Slider>();
 			volumeSlider.value = PlayerPrefs.GetFloat("Volume", Audio.DEFAULT_VOLUME);
-			volumeSlider.onValueChanged.AddListener(delegate {ValueChangeCheck(); });
+			volumeSlider.onValueChanged.AddListener(delegate { ValueChangeCheck(); });
 		}
 
 		private void ValueChangeCheck()

--- a/Assets/Project/Scripts/ConfigScene/VolumeController.cs
+++ b/Assets/Project/Scripts/ConfigScene/VolumeController.cs
@@ -1,16 +1,23 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
+﻿using UnityEngine;
+using UnityEngine.UI;
+using Project.Scripts.Utils.Definitions;
 
-public class VolumeController : MonoBehaviour {
+namespace Project.Scripts.ConfigScene
+{
+	public class VolumeController : MonoBehaviour
+	{
+		private Slider volumeSlider;
 
-	// Use this for initialization
-	void Start () {
-		
-	}
-	
-	// Update is called once per frame
-	void Update () {
-		
+		private void Awake()
+		{
+			volumeSlider = GetComponent<Slider>();
+			volumeSlider.value = PlayerPrefs.GetFloat("Volume", Audio.DEFAULT_VOLUME);
+			volumeSlider.onValueChanged.AddListener(delegate {ValueChangeCheck(); });
+		}
+
+		private void ValueChangeCheck()
+		{
+			PlayerPrefs.SetFloat("Volume", volumeSlider.value);
+		}
 	}
 }

--- a/Assets/Project/Scripts/ConfigScene/VolumeController.cs.meta
+++ b/Assets/Project/Scripts/ConfigScene/VolumeController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cc480e3a20fa044fdbed3d7df95ec7ed
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/Scripts/GamePlayScene/GamePlayDirector.cs
+++ b/Assets/Project/Scripts/GamePlayScene/GamePlayDirector.cs
@@ -269,7 +269,7 @@ namespace Project.Scripts.GamePlayScene
 			// Playing
 			gameObject.AddComponent<AudioSource>();
 			playingAudioSource = gameObject.GetComponents<AudioSource>()[0];
-			SetAudioSource(clipName: "playing", audioSource: playingAudioSource, time: 2.0f, loop: true);
+			SetAudioSource(clipName: "playing", audioSource: playingAudioSource, time: 2.0f, loop: true, volumeRate: 0.25f);
 			// Success
 			gameObject.AddComponent<AudioSource>();
 			successAudioSource = gameObject.GetComponents<AudioSource>()[1];
@@ -281,13 +281,13 @@ namespace Project.Scripts.GamePlayScene
 		}
 
 		/* 個々の音源のセットアップ (音源名 / 開始時間 / 繰り返し の設定) */
-		private static void SetAudioSource(string clipName, AudioSource audioSource, float time = 0.0f, bool loop = false)
+		private static void SetAudioSource(string clipName, AudioSource audioSource, float time = 0.0f, bool loop = false, float volumeRate = 1.0f)
 		{
 			var clip = Resources.Load<AudioClip>("Clips/GamePlayScene/" + clipName);
 			audioSource.clip = clip;
 			audioSource.time = time;
 			audioSource.loop = loop;
-			audioSource.volume = PlayerPrefs.GetFloat("Volume", Audio.DEFAULT_VOLUME);
+			audioSource.volume = PlayerPrefs.GetFloat("Volume", Audio.DEFAULT_VOLUME) * volumeRate;
 		}
 	}
 }

--- a/Assets/Project/Scripts/GamePlayScene/GamePlayDirector.cs
+++ b/Assets/Project/Scripts/GamePlayScene/GamePlayDirector.cs
@@ -269,26 +269,25 @@ namespace Project.Scripts.GamePlayScene
 			// Playing
 			gameObject.AddComponent<AudioSource>();
 			playingAudioSource = gameObject.GetComponents<AudioSource>()[0];
-			SetAudioSource(clipName: "playing", audioSource: playingAudioSource, time: 2.0f, volume: 0.10f, loop: true);
+			SetAudioSource(clipName: "playing", audioSource: playingAudioSource, time: 2.0f, loop: true);
 			// Success
 			gameObject.AddComponent<AudioSource>();
 			successAudioSource = gameObject.GetComponents<AudioSource>()[1];
-			SetAudioSource(clipName: "success", audioSource: successAudioSource, volume: 0.40f);
+			SetAudioSource(clipName: "success", audioSource: successAudioSource);
 			// Failure
 			gameObject.AddComponent<AudioSource>();
 			failureAudioSource = gameObject.GetComponents<AudioSource>()[2];
-			SetAudioSource(clipName: "failure", audioSource: failureAudioSource, volume: 0.40f);
+			SetAudioSource(clipName: "failure", audioSource: failureAudioSource);
 		}
 
-		/* 個々の音源のセットアップ (音源名 / 開始時間 / 音量 / 繰り返し の設定) */
-		private static void SetAudioSource(string clipName, AudioSource audioSource, float time = 0.0f,
-			float volume = 1.0f, bool loop = false)
+		/* 個々の音源のセットアップ (音源名 / 開始時間 / 繰り返し の設定) */
+		private static void SetAudioSource(string clipName, AudioSource audioSource, float time = 0.0f, bool loop = false)
 		{
 			var clip = Resources.Load<AudioClip>("Clips/GamePlayScene/" + clipName);
 			audioSource.clip = clip;
 			audioSource.time = time;
-			audioSource.volume = volume;
 			audioSource.loop = loop;
+			audioSource.volume = PlayerPrefs.GetFloat("Volume", Audio.DEFAULT_VOLUME);
 		}
 	}
 }

--- a/Assets/Project/Scripts/GamePlayScene/GamePlayDirector.cs
+++ b/Assets/Project/Scripts/GamePlayScene/GamePlayDirector.cs
@@ -75,6 +75,7 @@ namespace Project.Scripts.GamePlayScene
 			}
 		}
 
+		/* ゲームのクリア判定 */
 		public void CheckClear()
 		{
 			GameObject[] panels = GameObject.FindGameObjectsWithTag("NumberPanel");
@@ -83,7 +84,7 @@ namespace Project.Scripts.GamePlayScene
 			Dispatch(GameState.Success);
 		}
 
-		// 状態による振り分け処理
+		/* 状態遷移 */
 		public bool Dispatch(GameState nextState)
 		{
 			switch (nextState)
@@ -135,6 +136,7 @@ namespace Project.Scripts.GamePlayScene
 			return false;
 		}
 
+		/* ゲーム起動時 */
 		private void GameOpening()
 		{
 			CleanObject();
@@ -162,11 +164,13 @@ namespace Project.Scripts.GamePlayScene
 			Dispatch(GameState.Playing);
 		}
 
+		/* ゲーム開始時 */
 		private void GamePlaying()
 		{
 			playingAudioSource.Play();
 		}
 
+		/* ゲーム成功時 */
 		private void GameSucceed()
 		{
 			if (OnSucceed != null) OnSucceed();
@@ -180,6 +184,7 @@ namespace Project.Scripts.GamePlayScene
 			ss.IncSuccessNum(stageId);
 		}
 
+		/* ゲーム失敗時 */
 		private void GameFail()
 		{
 			if (OnFail != null) OnFail();
@@ -191,12 +196,14 @@ namespace Project.Scripts.GamePlayScene
 			ss.IncFailureNum(stageId);
 		}
 
+		/* ゲーム終了時の共通処理 */
 		private void EndProcess()
 		{
 			playingAudioSource.Stop();
 			resultWindow.SetActive(true);
 		}
 
+		/* リトライボタン押下時 */
 		public void RetryButtonDown()
 		{
 			// 挑戦回数をインクリメント
@@ -205,12 +212,14 @@ namespace Project.Scripts.GamePlayScene
 			Dispatch(GameState.Opening);
 		}
 
+		/* 戻るボタン押下時 */
 		public void BackButtonDown()
 		{
 			// StageSelectSceneに戻る
 			SceneManager.LoadScene("MenuBarScene");
 		}
 
+		/* タイル・パネル・銃弾オブジェクトの削除 */
 		private static void CleanObject()
 		{
 			GameObject[] tiles = GameObject.FindGameObjectsWithTag("Tile");
@@ -228,6 +237,7 @@ namespace Project.Scripts.GamePlayScene
 			}
 		}
 
+		/* ゲーム画面のアスペクト比を統一する */
 		private static void UnifyDisplay()
 		{
 			// 想定するデバイスのアスペクト比
@@ -252,6 +262,7 @@ namespace Project.Scripts.GamePlayScene
 			}
 		}
 
+		/* 音源のセットアップ */
 		private void SetAudioSources()
 		{
 			// 各音源の設定
@@ -269,7 +280,7 @@ namespace Project.Scripts.GamePlayScene
 			SetAudioSource(clipName: "failure", audioSource: failureAudioSource, volume: 0.40f);
 		}
 
-		// AudioSourceの変数(音源名、開始時間、音量、繰り返しの有無)の設定
+		/* 個々の音源のセットアップ (音源名 / 開始時間 / 音量 / 繰り返し の設定) */
 		private static void SetAudioSource(string clipName, AudioSource audioSource, float time = 0.0f,
 			float volume = 1.0f, bool loop = false)
 		{

--- a/Assets/Project/Scripts/GamePlayScene/GamePlayDirector.cs
+++ b/Assets/Project/Scripts/GamePlayScene/GamePlayDirector.cs
@@ -269,7 +269,8 @@ namespace Project.Scripts.GamePlayScene
 			// Playing
 			gameObject.AddComponent<AudioSource>();
 			playingAudioSource = gameObject.GetComponents<AudioSource>()[0];
-			SetAudioSource(clipName: "playing", audioSource: playingAudioSource, time: 2.0f, loop: true, volumeRate: 0.25f);
+			SetAudioSource(clipName: "playing", audioSource: playingAudioSource, time: 2.0f, loop: true,
+				volumeRate: 0.25f);
 			// Success
 			gameObject.AddComponent<AudioSource>();
 			successAudioSource = gameObject.GetComponents<AudioSource>()[1];
@@ -281,7 +282,8 @@ namespace Project.Scripts.GamePlayScene
 		}
 
 		/* 個々の音源のセットアップ (音源名 / 開始時間 / 繰り返し の設定) */
-		private static void SetAudioSource(string clipName, AudioSource audioSource, float time = 0.0f, bool loop = false, float volumeRate = 1.0f)
+		private static void SetAudioSource(string clipName, AudioSource audioSource, float time = 0.0f,
+			bool loop = false, float volumeRate = 1.0f)
 		{
 			var clip = Resources.Load<AudioClip>("Clips/GamePlayScene/" + clipName);
 			audioSource.clip = clip;

--- a/Assets/Project/Scripts/GamePlayScene/GamePlayDirector.cs
+++ b/Assets/Project/Scripts/GamePlayScene/GamePlayDirector.cs
@@ -56,7 +56,7 @@ namespace Project.Scripts.GamePlayScene
 			warningText = resultWindow.transform.Find("Warning").gameObject;
 			stageNumberText = GameObject.Find("StageNumberText");
 
-			SetAudioSource();
+			SetAudioSources();
 		}
 
 		private void Start()
@@ -252,7 +252,7 @@ namespace Project.Scripts.GamePlayScene
 			}
 		}
 
-		private void SetAudioSource()
+		private void SetAudioSources()
 		{
 			// 各音源の設定
 			// Playing

--- a/Assets/Project/Scripts/GamePlayScene/StageGenerator.cs
+++ b/Assets/Project/Scripts/GamePlayScene/StageGenerator.cs
@@ -38,8 +38,8 @@ namespace Project.Scripts.GamePlayScene
 						(int) Row.Second, 1.0f, 1.0f,
 						new int[,]
 						{
-							{(int)CartridgeDirection.ToUp, (int)Column.Right},
-							{(int)CartridgeDirection.ToLeft, (int)Row.First}
+							{(int) CartridgeDirection.ToUp, (int) Column.Right},
+							{(int) CartridgeDirection.ToLeft, (int) Row.First}
 						}));
 					coroutines.Add(bulletGenerator.CreateCartridge(CartridgeType.Normal,
 						CartridgeDirection.ToUp,

--- a/Assets/Project/Scripts/GamePlayScene/Tile/TileGenerator.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Tile/TileGenerator.cs
@@ -96,7 +96,8 @@ namespace Project.Scripts.GamePlayScene.Tile
 					var upperTile = i == 0 ? null : tiles[i - 1, j];
 					var lowerTile = i + 1 == row ? null : tiles[i + 1, j];
 					// タイルオブジェクトのスクリプトに上下左右のタイルオブジェクトを格納する
-					tiles[i, j].GetComponent<NormalTileController>().MakeRelation(rightTile, leftTile, upperTile, lowerTile);
+					tiles[i, j].GetComponent<NormalTileController>()
+						.MakeRelation(rightTile, leftTile, upperTile, lowerTile);
 				}
 			}
 		}

--- a/Assets/Project/Scripts/Utils/Definitions/AudioDefinitions.cs
+++ b/Assets/Project/Scripts/Utils/Definitions/AudioDefinitions.cs
@@ -1,0 +1,7 @@
+﻿namespace Project.Scripts.Utils.Definitions
+{
+	public static class Audio
+	{
+		public const float DEFAULT_VOLUME = 0.5f;
+	}
+}

--- a/Assets/Project/Scripts/Utils/Definitions/AudioDefinitions.cs.meta
+++ b/Assets/Project/Scripts/Utils/Definitions/AudioDefinitions.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 38115130d96946abb3fd7a99a441eb41
+timeCreated: 1555938056


### PR DESCRIPTION
## 対象イシュー
https://app.mmth.pro/projects/18382/tasks#/show/228576

## 概要
設定画面における，音量のスライダーを用いて音量調整できるようになった．
- 音量のスライダーを設定画面の一番上に置きました
- デフォルトの音量を指定できるようにしました
- 各音源に対して，絶対音量に対する比を指定できるようにしました

### その他
- 音量調整周りのメソッドの一部改修を行いました
- 一部コメントを追加しました

## 技術的な内容
- Volume パネルの子供にある，スライダーに `VolumeController` スクリプトをアタッチしました
- `AudioDefinitions` にデフォルト音量を記述しました
