### PR TITLE
BulletDefinitionsではなく，メソッドで分割する

### DIFF
--- a/Assets/Project/Scripts/GamePlayScene/Bullet/BulletGenerator.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/BulletGenerator.cs
@@ -47,9 +47,14 @@ namespace Project.Scripts.GamePlayScene.Bullet
 			foreach (var coroutine in coroutines) StartCoroutine(coroutine);
 		}
 
+		public Dictionary<string, int[]> SetTurnInfo(int[] direction, int[] line)
+		{
+			return new Dictionary<string, int[]> {{"TurnDirection", direction}, {"TurnLine", line}};
+		}
+
 		// 指定した行(or列)の端から一定の時間間隔(interval)で弾丸を作成するメソッド
 		public IEnumerator CreateCartridge(CartridgeType cartridgeType, CartridgeDirection direction, int line,
-			float appearanceTime, float interval, int[,] additionalInfo = null)
+			float appearanceTime, float interval, Dictionary<string, int[]> dictionary = null)
 		{
 			var currentTime = Time.time;
 
@@ -64,7 +69,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
 			while (true)
 			{
 				sum++;
-				StartCoroutine(CreateOneCartridge(cartridgeType, direction, line, bulletId, additionalInfo));
+				StartCoroutine(CreateOneCartridge(cartridgeType, direction, line, bulletId, dictionary));
 
 				// 作成する銃弾の個数の上限チェック
 				try
@@ -85,7 +90,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
 
 		// warningの表示が終わる時刻を待ち、cartridgeを作成するメソッド
 		private IEnumerator CreateOneCartridge(CartridgeType cartridgeType, CartridgeDirection direction, int line,
-			short cartridgeId, int[,] additionalInfo)
+			short cartridgeId, Dictionary<string, int[]> dictionary)
 		{
 			// 作成するcartidgeの種類で分岐
 			GameObject warning;
@@ -127,7 +132,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
 					case CartridgeType.Turn:
 						cartridge = Instantiate(turnCartridgePrefab);
 						cartridge.GetComponent<TurnCartridgeController>()
-							.Initialize(direction, line, bulletMotionVector, additionalInfo);
+							.Initialize(direction, line, bulletMotionVector, dictionary);
 						break;
 					default:
 						throw new NotImplementedException();

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/BulletGenerator.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/BulletGenerator.cs
@@ -54,7 +54,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
 
 		// 指定した行(or列)の端から一定の時間間隔(interval)で弾丸を作成するメソッド
 		public IEnumerator CreateCartridge(CartridgeType cartridgeType, CartridgeDirection direction, int line,
-			float appearanceTime, float interval, Dictionary<string, int[]> dictionary = null)
+			float appearanceTime, float interval, Dictionary<string, int[]> additionalInfo = null)
 		{
 			var currentTime = Time.time;
 
@@ -69,7 +69,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
 			while (true)
 			{
 				sum++;
-				StartCoroutine(CreateOneCartridge(cartridgeType, direction, line, bulletId, dictionary));
+				StartCoroutine(CreateOneCartridge(cartridgeType, direction, line, bulletId, additionalInfo));
 
 				// 作成する銃弾の個数の上限チェック
 				try
@@ -90,7 +90,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
 
 		// warningの表示が終わる時刻を待ち、cartridgeを作成するメソッド
 		private IEnumerator CreateOneCartridge(CartridgeType cartridgeType, CartridgeDirection direction, int line,
-			short cartridgeId, Dictionary<string, int[]> dictionary)
+			short cartridgeId, Dictionary<string, int[]> additionalInfo)
 		{
 			// 作成するcartidgeの種類で分岐
 			GameObject warning;
@@ -132,7 +132,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
 					case CartridgeType.Turn:
 						cartridge = Instantiate(turnCartridgePrefab);
 						cartridge.GetComponent<TurnCartridgeController>()
-							.Initialize(direction, line, bulletMotionVector, dictionary);
+							.Initialize(direction, line, bulletMotionVector, additionalInfo);
 						break;
 					default:
 						throw new NotImplementedException();

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/BulletGenerator.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/BulletGenerator.cs
@@ -47,9 +47,9 @@ namespace Project.Scripts.GamePlayScene.Bullet
 			foreach (var coroutine in coroutines) StartCoroutine(coroutine);
 		}
 
-		public Dictionary<string, int[]> SetTurnInfo(int[] direction, int[] line)
+		public Dictionary<string, int[]> SetTurnInfo(int[] turnDirection, int[] turnLine)
 		{
-			return new Dictionary<string, int[]> {{"TurnDirection", direction}, {"TurnLine", line}};
+			return new Dictionary<string, int[]> {{"TurnDirection", turnDirection}, {"TurnLine", turnLine}};
 		}
 
 		// 指定した行(or列)の端から一定の時間間隔(interval)で弾丸を作成するメソッド

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/TurnCartridgeController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/TurnCartridgeController.cs
@@ -108,13 +108,13 @@ namespace Project.Scripts.GamePlayScene.Bullet
 		}
 
 		public void Initialize(CartridgeDirection direction, int line, Vector2 motionVector,
-			Dictionary<string, int[]> dictionary)
+			Dictionary<string, int[]> additionalInfo)
 		{
 			Initialize(direction, line, motionVector);
 
 			// どのタイル上でどの方向に曲がるかの引数を受け取る
-			turnDirection = dictionary["TurnDirection"];
-			turnLine = dictionary["TurnLine"];
+			turnDirection = additionalInfo["TurnDirection"];
+			turnLine = additionalInfo["TurnLine"];
 
 			// 銃弾が曲がるタイルの座標
 			turnPoint = transform.position * Abs(Transposition(motionVector)) + new Vector2(

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/TurnCartridgeController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/TurnCartridgeController.cs
@@ -79,8 +79,10 @@ namespace Project.Scripts.GamePlayScene.Bullet
 				// 別のタイル上でまだ回転する場合
 				if (turnDirection.Length >= 2)
 				{
+					// 配列の先頭要素を除く部分配列を取得する
 					turnDirection = turnDirection.Skip(1).Take(turnDirection.Length - 1).ToArray();
 					turnLine = turnLine.Skip(1).Take(turnLine.Length - 1).ToArray();
+
 					turnPoint = transform.position * Abs(Transposition(motionVector)) + new Vector2(
 						            TileSize.WIDTH * (turnLine[0] - 2),
 						            WindowSize.HEIGHT * 0.5f - (TileSize.MARGIN_TOP + TileSize.HEIGHT * 0.5f) -

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/TurnCartridgeController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/TurnCartridgeController.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using Project.Scripts.GamePlayScene.BulletWarning;
 using Project.Scripts.Utils.Definitions;
 using UnityEngine;
@@ -9,10 +10,10 @@ namespace Project.Scripts.GamePlayScene.Bullet
 	public class TurnCartridgeController : NormalCartridgeController
 	{
 		// 回転方向
-		private List<int> turnDirection = new List<int>();
+		private int[] turnDirection;
 
 		// 回転する列(or行)
-		private List<int> turnLine = new List<int>();
+		private int[] turnLine;
 
 		// 回転に関する警告を表示する座標
 		private Vector2 turnPoint;
@@ -76,10 +77,10 @@ namespace Project.Scripts.GamePlayScene.Bullet
 				transform.Rotate(new Vector3(0, 0, turnAngle / 2f / Mathf.PI * 180f), Space.World);
 				motionVector = Rotate(motionVector, turnAngle / 2f);
 				// 別のタイル上でまだ回転する場合
-				if (turnDirection.Count >= 2)
+				if (turnDirection.Length >= 2)
 				{
-					turnDirection.RemoveAt(0);
-					turnLine.RemoveAt(0);
+					turnDirection = turnDirection.Skip(1).Take(turnDirection.Length - 1).ToArray();
+					turnLine = turnLine.Skip(1).Take(turnLine.Length - 1).ToArray();
 					turnPoint = transform.position * Abs(Transposition(motionVector)) + new Vector2(
 						            TileSize.WIDTH * (turnLine[0] - 2),
 						            WindowSize.HEIGHT * 0.5f - (TileSize.MARGIN_TOP + TileSize.HEIGHT * 0.5f) -
@@ -105,16 +106,13 @@ namespace Project.Scripts.GamePlayScene.Bullet
 		}
 
 		public void Initialize(CartridgeDirection direction, int line, Vector2 motionVector,
-			int[,] additionalInfo)
+			Dictionary<string, int[]> dictionary)
 		{
 			Initialize(direction, line, motionVector);
 
 			// どのタイル上でどの方向に曲がるかの引数を受け取る
-			for (var i = 0; i < additionalInfo.GetLength(0); i++)
-			{
-				turnDirection.Add(additionalInfo[i, 0]);
-				turnLine.Add(additionalInfo[i, 1]);
-			}
+			turnDirection = dictionary["TurnDirection"];
+			turnLine = dictionary["TurnLine"];
 
 			// 銃弾が曲がるタイルの座標
 			turnPoint = transform.position * Abs(Transposition(motionVector)) + new Vector2(

--- a/Assets/Project/Scripts/GamePlayScene/StageGenerator.cs
+++ b/Assets/Project/Scripts/GamePlayScene/StageGenerator.cs
@@ -37,8 +37,8 @@ namespace Project.Scripts.GamePlayScene
 						CartridgeDirection.ToLeft,
 						(int) Row.Second, 1.0f, 1.0f,
 						bulletGenerator.SetTurnInfo(
-							direction: new[] {(int) CartridgeDirection.ToUp, (int) CartridgeDirection.ToLeft},
-							line: new[] {(int) Column.Right, (int) Row.First})));
+							turnDirection: new[] {(int) CartridgeDirection.ToUp, (int) CartridgeDirection.ToLeft},
+							turnLine: new[] {(int) Column.Right, (int) Row.First})));
 					coroutines.Add(bulletGenerator.CreateCartridge(CartridgeType.Normal,
 						CartridgeDirection.ToUp,
 						(int) Column.Right, 2.0f, 4.0f));

--- a/Assets/Project/Scripts/GamePlayScene/StageGenerator.cs
+++ b/Assets/Project/Scripts/GamePlayScene/StageGenerator.cs
@@ -36,11 +36,9 @@ namespace Project.Scripts.GamePlayScene
 					coroutines.Add(bulletGenerator.CreateCartridge(CartridgeType.Turn,
 						CartridgeDirection.ToLeft,
 						(int) Row.Second, 1.0f, 1.0f,
-						new int[,]
-						{
-							{(int) CartridgeDirection.ToUp, (int) Column.Right},
-							{(int) CartridgeDirection.ToLeft, (int) Row.First}
-						}));
+						bulletGenerator.SetTurnInfo(
+							new[] {(int) CartridgeDirection.ToUp, (int) CartridgeDirection.ToLeft},
+							new[] {(int) Column.Right, (int) Row.First})));
 					coroutines.Add(bulletGenerator.CreateCartridge(CartridgeType.Normal,
 						CartridgeDirection.ToUp,
 						(int) Column.Right, 2.0f, 4.0f));

--- a/Assets/Project/Scripts/GamePlayScene/StageGenerator.cs
+++ b/Assets/Project/Scripts/GamePlayScene/StageGenerator.cs
@@ -37,8 +37,8 @@ namespace Project.Scripts.GamePlayScene
 						CartridgeDirection.ToLeft,
 						(int) Row.Second, 1.0f, 1.0f,
 						bulletGenerator.SetTurnInfo(
-							new[] {(int) CartridgeDirection.ToUp, (int) CartridgeDirection.ToLeft},
-							new[] {(int) Column.Right, (int) Row.First})));
+							direction: new[] {(int) CartridgeDirection.ToUp, (int) CartridgeDirection.ToLeft},
+							line: new[] {(int) Column.Right, (int) Row.First})));
 					coroutines.Add(bulletGenerator.CreateCartridge(CartridgeType.Normal,
 						CartridgeDirection.ToUp,
 						(int) Column.Right, 2.0f, 4.0f));


### PR DESCRIPTION
## 対象イシュー
https://app.mmth.pro/projects/18382/tasks#/show/228796

## 概要
銃弾生成時に必要とする、銃弾毎に異なる引数については、各銃弾毎に用意されたメソッドを用いて設定する。

## 技術的な内容
- 銃弾毎に必要な引数について、引数名をkey, その値の配列int[]をvalueとする`Dictionary<string, int[]>`を返り値とするメソッド`SetTurnInfo()`を`BulletGenerator.cs`に記述。
- 今後、銃弾の種類が増えた時に、その銃弾に対応するメソッド`Set****Info()`を併せて記述する。
- `Dictionary<string, int>`型を受け取るように、メソッドを変更
- `SetTurnInfo()`を用いてステージ生成を行うように変更

## キャプチャ
