### PR TITLE
難易度によって選択できるステージを変える

### DIFF
--- a/Assets/Project/Scripts/GamePlayScene/GamePlayDirector.cs
+++ b/Assets/Project/Scripts/GamePlayScene/GamePlayDirector.cs
@@ -216,7 +216,7 @@ namespace Project.Scripts.GamePlayScene
 		public void BackButtonDown()
 		{
 			// StageSelectSceneに戻る
-			SceneManager.LoadScene("MenuBarScene");
+			SceneManager.LoadScene("MenuSelectScene");
 		}
 
 		/* タイル・パネル・銃弾オブジェクトの削除 */

--- a/Assets/Project/Scripts/LevelSelectScene/LevelSelectDirector.cs
+++ b/Assets/Project/Scripts/LevelSelectScene/LevelSelectDirector.cs
@@ -69,14 +69,20 @@ namespace Project.Scripts.LevelSelectScene
 				ToggleValueChanged(easyStageSelectToggle);
 			});
 
-			normalStageSelectToggle.GetComponent<Toggle>().onValueChanged.
-				AddListener(delegate { ToggleValueChanged(normalStageSelectToggle); });
+			normalStageSelectToggle.GetComponent<Toggle>().onValueChanged.AddListener(delegate
+			{
+				ToggleValueChanged(normalStageSelectToggle);
+			});
 
-			hardStageSelectToggle.GetComponent<Toggle>().onValueChanged.
-				AddListener(delegate { ToggleValueChanged(hardStageSelectToggle); });
+			hardStageSelectToggle.GetComponent<Toggle>().onValueChanged.AddListener(delegate
+			{
+				ToggleValueChanged(hardStageSelectToggle);
+			});
 
-			veryHardStageSelectToggle.GetComponent<Toggle>().onValueChanged.
-				AddListener(delegate { ToggleValueChanged(veryHardStageSelectToggle); });
+			veryHardStageSelectToggle.GetComponent<Toggle>().onValueChanged.AddListener(delegate
+			{
+				ToggleValueChanged(veryHardStageSelectToggle);
+			});
 		}
 
 		private void ToggleValueChanged(GameObject toggle)

--- a/Assets/Project/Scripts/StageSelectScene/EasyStageSelectDirector.cs
+++ b/Assets/Project/Scripts/StageSelectScene/EasyStageSelectDirector.cs
@@ -1,12 +1,40 @@
 ﻿using UnityEngine;
+﻿using Project.Scripts.Utils.Definitions;
+using UnityEngine.UI;
 
 namespace Project.Scripts.StageSelectScene
 {
 	public class EasyStageSelectDirector : StageSelectDirector
 	{
-		protected override Color SetButtonColor()
+		protected override void MakeButtons()
 		{
-			return new Color(1.0f, 1.0f, 1.0f);
+			var content = GameObject.Find("Canvas/Scroll View/Viewport/Content/Buttons").GetComponent<RectTransform>();
+			for (var i = 0; i < StageNum.EASY; i++)
+			{
+				// ステージを一意に定めるID
+				var stageId = StageStartId.EASY + i;
+				// ボタンインスタンスを生成
+				var button = Instantiate(stageButtonPrefab);
+				// 名前
+				button.name = stageId.ToString();
+				// 親ディレクトリ
+				button.transform.SetParent(content, false);
+				// 表示テキスト
+				button.GetComponentInChildren<Text>().text = "ステージ" + stageId + "へ";
+				// クリック時のリスナー
+				button.GetComponent<Button>().onClick.AddListener(() => StageButtonDown(button));
+				// Buttonの色
+				button.GetComponent<Image>().color = new Color(1.0f, 1.0f, 1.0f);
+				// Buttonの位置
+				var rectTransform = button.GetComponent<RectTransform>();
+				// 下部のマージン : 0.05f
+				// ボタン間の間隔 : 0.10f
+				var buttonPositionY = 0.05f + i * 0.10f;
+				// ボタンの縦幅 : 0.04f (上に0.02f, 下に0.02fをアンカー中央から伸ばす)
+				rectTransform.anchorMax = new Vector2(0.90f, buttonPositionY + 0.02f);
+				rectTransform.anchorMin = new Vector2(0.10f, buttonPositionY - 0.02f);
+				rectTransform.anchoredPosition = new Vector2(0.50f, buttonPositionY);
+			}
 		}
 	}
 }

--- a/Assets/Project/Scripts/StageSelectScene/EasyStageSelectDirector.cs
+++ b/Assets/Project/Scripts/StageSelectScene/EasyStageSelectDirector.cs
@@ -1,5 +1,5 @@
 ﻿using UnityEngine;
-﻿using Project.Scripts.Utils.Definitions;
+using Project.Scripts.Utils.Definitions;
 using UnityEngine.UI;
 
 namespace Project.Scripts.StageSelectScene

--- a/Assets/Project/Scripts/StageSelectScene/HardStageSelectDirector.cs
+++ b/Assets/Project/Scripts/StageSelectScene/HardStageSelectDirector.cs
@@ -1,5 +1,5 @@
-﻿using Project.Scripts.Utils.Definitions;
-using UnityEngine;
+﻿using UnityEngine;
+using Project.Scripts.Utils.Definitions;
 using UnityEngine.UI;
 
 namespace Project.Scripts.StageSelectScene

--- a/Assets/Project/Scripts/StageSelectScene/HardStageSelectDirector.cs
+++ b/Assets/Project/Scripts/StageSelectScene/HardStageSelectDirector.cs
@@ -1,12 +1,40 @@
-﻿using UnityEngine;
+﻿using Project.Scripts.Utils.Definitions;
+using UnityEngine;
+using UnityEngine.UI;
 
 namespace Project.Scripts.StageSelectScene
 {
 	public class HardStageSelectDirector : StageSelectDirector
 	{
-		protected override Color SetButtonColor()
+		protected override void MakeButtons()
 		{
-			return new Color(1.0f, 0.50f, 0.50f);
+			var content = GameObject.Find("Canvas/Scroll View/Viewport/Content/Buttons").GetComponent<RectTransform>();
+			for (var i = 0; i < StageNum.HARD; i++)
+			{
+				// ステージを一意に定めるID
+				var stageId = StageStartId.HARD + i;
+				// ボタンインスタンスを生成
+				var button = Instantiate(stageButtonPrefab);
+				// 名前
+				button.name = stageId.ToString();
+				// 親ディレクトリ
+				button.transform.SetParent(content, false);
+				// 表示テキスト
+				button.GetComponentInChildren<Text>().text = "ステージ" + stageId + "へ";
+				// クリック時のリスナー
+				button.GetComponent<Button>().onClick.AddListener(() => StageButtonDown(button));
+				// Buttonの色
+				button.GetComponent<Image>().color = new Color(1.0f, 0.75f, 0.75f);
+				// Buttonの位置
+				var rectTransform = button.GetComponent<RectTransform>();
+				// 下部のマージン : 0.05f
+				// ボタン間の間隔 : 0.10f
+				var buttonPositionY = 0.05f + i * 0.10f;
+				// ボタンの縦幅 : 0.04f (上に0.02f, 下に0.02fをアンカー中央から伸ばす)
+				rectTransform.anchorMax = new Vector2(0.90f, buttonPositionY + 0.02f);
+				rectTransform.anchorMin = new Vector2(0.10f, buttonPositionY - 0.02f);
+				rectTransform.anchoredPosition = new Vector2(0.50f, buttonPositionY);
+			}
 		}
 	}
 }

--- a/Assets/Project/Scripts/StageSelectScene/NormalStageSelectDirector.cs
+++ b/Assets/Project/Scripts/StageSelectScene/NormalStageSelectDirector.cs
@@ -1,12 +1,40 @@
 ﻿using UnityEngine;
+﻿using Project.Scripts.Utils.Definitions;
+using UnityEngine.UI;
 
 namespace Project.Scripts.StageSelectScene
 {
 	public class NormalStageSelectDirector : StageSelectDirector
 	{
-		protected override Color SetButtonColor()
+		protected override void MakeButtons()
 		{
-			return new Color(1.0f, 0.75f, 0.75f);
+			var content = GameObject.Find("Canvas/Scroll View/Viewport/Content/Buttons").GetComponent<RectTransform>();
+			for (var i = 0; i < StageNum.NORMAL; i++)
+			{
+				// ステージを一意に定めるID
+				var stageId = StageStartId.NORMAL + i;
+				// ボタンインスタンスを生成
+				var button = Instantiate(stageButtonPrefab);
+				// 名前
+				button.name = stageId.ToString();
+				// 親ディレクトリ
+				button.transform.SetParent(content, false);
+				// 表示テキスト
+				button.GetComponentInChildren<Text>().text = "ステージ" + stageId + "へ";
+				// クリック時のリスナー
+				button.GetComponent<Button>().onClick.AddListener(() => StageButtonDown(button));
+				// Buttonの色
+				button.GetComponent<Image>().color = new Color(1.0f, 0.75f, 0.75f);
+				// Buttonの位置
+				var rectTransform = button.GetComponent<RectTransform>();
+				// 下部のマージン : 0.05f
+				// ボタン間の間隔 : 0.10f
+				var buttonPositionY = 0.05f + i * 0.10f;
+				// ボタンの縦幅 : 0.04f (上に0.02f, 下に0.02fをアンカー中央から伸ばす)
+				rectTransform.anchorMax = new Vector2(0.90f, buttonPositionY + 0.02f);
+				rectTransform.anchorMin = new Vector2(0.10f, buttonPositionY - 0.02f);
+				rectTransform.anchoredPosition = new Vector2(0.50f, buttonPositionY);
+			}
 		}
 	}
 }

--- a/Assets/Project/Scripts/StageSelectScene/StageSelectDirector.cs
+++ b/Assets/Project/Scripts/StageSelectScene/StageSelectDirector.cs
@@ -2,7 +2,6 @@
 using Project.Scripts.Utils.PlayerPrefsUtils;
 using UnityEngine;
 using UnityEngine.SceneManagement;
-using UnityEngine.UI;
 
 namespace Project.Scripts.StageSelectScene
 {

--- a/Assets/Project/Scripts/StageSelectScene/StageSelectDirector.cs
+++ b/Assets/Project/Scripts/StageSelectScene/StageSelectDirector.cs
@@ -35,16 +35,6 @@ namespace Project.Scripts.StageSelectScene
 			// 挑戦回数をインクリメント
 			var ss = StageStatus.Get(stageId);
 			ss.IncChallengeNum(stageId);
-			// リセットのデバッグ用
-			if (stageId == 1)
-			{
-				StageStatus.Reset(2);
-			}
-			else if (stageId == 2)
-			{
-				StageStatus.Reset(1);
-			}
-
 			// ステージ番号を渡す
 			GamePlayDirector.stageId = stageId;
 			// シーン遷移

--- a/Assets/Project/Scripts/StageSelectScene/StageSelectDirector.cs
+++ b/Assets/Project/Scripts/StageSelectScene/StageSelectDirector.cs
@@ -28,7 +28,7 @@ namespace Project.Scripts.StageSelectScene
 			}
 		}
 
-		private static void StageButtonDown(GameObject clickedButton)
+		protected static void StageButtonDown(GameObject clickedButton)
 		{
 			// タップされたステージidを取得（暫定的にボタンの名前）
 			var stageId = int.Parse(clickedButton.name);
@@ -51,31 +51,7 @@ namespace Project.Scripts.StageSelectScene
 			SceneManager.LoadScene("GamePlayScene");
 		}
 
-		// ボタンの生成
-		private void MakeButtons()
-		{
-			var content = GameObject.Find("Canvas/Scroll View/Viewport/Content/Buttons").GetComponent<RectTransform>();
-			for (var i = 0; i < 10; i++)
-			{
-				var button = Instantiate(stageButtonPrefab);
-				button.name = (i + 1).ToString();
-				button.transform.SetParent(content, false);
-				button.GetComponentInChildren<Text>().text = "ステージ" + (i + 1) + "へ";
-				button.GetComponent<Button>().onClick.AddListener(() => StageButtonDown(button));
-				// Buttonの色
-				button.GetComponent<Image>().color = SetButtonColor();
-				// Buttonの位置
-				var rectTransform = button.GetComponent<RectTransform>();
-				// 下部のマージン : 0.05f
-				// ボタン間の間隔 : 0.10f
-				var buttonPositionY = 0.05f + i * 0.10f;
-				// ボタンの縦幅 : 0.04f (上に0.02f, 下に0.02fをアンカー中央から伸ばす)
-				rectTransform.anchorMax = new Vector2(0.90f, buttonPositionY + 0.02f);
-				rectTransform.anchorMin = new Vector2(0.10f, buttonPositionY - 0.02f);
-				rectTransform.anchoredPosition = new Vector2(0.50f, buttonPositionY);
-			}
-		}
-
-		protected abstract Color SetButtonColor();
+		/* ボタンの生成 */
+		protected abstract void MakeButtons();
 	}
 }

--- a/Assets/Project/Scripts/StageSelectScene/StageSelectDirector.cs
+++ b/Assets/Project/Scripts/StageSelectScene/StageSelectDirector.cs
@@ -14,18 +14,6 @@ namespace Project.Scripts.StageSelectScene
 		{
 			// ボタンの作成
 			MakeButtons();
-			// Buttonのリスナーを設定
-			SetListener();
-		}
-
-		private static void SetListener()
-		{
-			// Buttons/*にリスナーを登録
-			foreach (Transform child in GameObject.Find("Buttons").transform)
-			{
-				var obj = child.gameObject;
-				obj.GetComponent<Button>().onClick.AddListener(() => StageButtonDown(obj));
-			}
 		}
 
 		protected static void StageButtonDown(GameObject clickedButton)

--- a/Assets/Project/Scripts/StageSelectScene/VeryHardStageSelectDirector.cs
+++ b/Assets/Project/Scripts/StageSelectScene/VeryHardStageSelectDirector.cs
@@ -1,12 +1,40 @@
 ﻿using UnityEngine;
+﻿using Project.Scripts.Utils.Definitions;
+using UnityEngine.UI;
 
 namespace Project.Scripts.StageSelectScene
 {
 	public class VeryHardStageSelectDirector : StageSelectDirector
 	{
-		protected override Color SetButtonColor()
+		protected override void MakeButtons()
 		{
-			return new Color(1.0f, 0.25f, 0.25f);
+			var content = GameObject.Find("Canvas/Scroll View/Viewport/Content/Buttons").GetComponent<RectTransform>();
+			for (var i = 0; i < StageNum.VERY_HARD; i++)
+			{
+				// ステージを一意に定めるID
+				var stageId = StageStartId.VERY_HARD + i;
+				// ボタンインスタンスを生成
+				var button = Instantiate(stageButtonPrefab);
+				// 名前
+				button.name = stageId.ToString();
+				// 親ディレクトリ
+				button.transform.SetParent(content, false);
+				// 表示テキスト
+				button.GetComponentInChildren<Text>().text = "ステージ" + stageId + "へ";
+				// クリック時のリスナー
+				button.GetComponent<Button>().onClick.AddListener(() => StageButtonDown(button));
+				// Buttonの色
+				button.GetComponent<Image>().color = new Color(1.0f, 0.75f, 0.75f);
+				// Buttonの位置
+				var rectTransform = button.GetComponent<RectTransform>();
+				// 下部のマージン : 0.05f
+				// ボタン間の間隔 : 0.10f
+				var buttonPositionY = 0.05f + i * 0.10f;
+				// ボタンの縦幅 : 0.04f (上に0.02f, 下に0.02fをアンカー中央から伸ばす)
+				rectTransform.anchorMax = new Vector2(0.90f, buttonPositionY + 0.02f);
+				rectTransform.anchorMin = new Vector2(0.10f, buttonPositionY - 0.02f);
+				rectTransform.anchoredPosition = new Vector2(0.50f, buttonPositionY);
+			}
 		}
 	}
 }

--- a/Assets/Project/Scripts/StageSelectScene/VeryHardStageSelectDirector.cs
+++ b/Assets/Project/Scripts/StageSelectScene/VeryHardStageSelectDirector.cs
@@ -1,5 +1,5 @@
 ﻿using UnityEngine;
-﻿using Project.Scripts.Utils.Definitions;
+using Project.Scripts.Utils.Definitions;
 using UnityEngine.UI;
 
 namespace Project.Scripts.StageSelectScene

--- a/Assets/Project/Scripts/Utils/Definitions/StageDefinitions.cs
+++ b/Assets/Project/Scripts/Utils/Definitions/StageDefinitions.cs
@@ -10,9 +10,9 @@
 
 	public static class StageStartId
 	{
-		public const int EASY = 0;
-		public const int NORMAL = EASY + StageNum.EASY;
-		public const int HARD = NORMAL + StageNum.NORMAL;
-		public const int VERY_HARD = HARD + StageNum.HARD;
+		public const int EASY = 1;
+		public const int NORMAL = 1001;
+		public const int HARD = 2001;
+		public const int VERY_HARD = 3001;
 	}
 }

--- a/Assets/Project/Scripts/Utils/Definitions/StageDefinitions.cs
+++ b/Assets/Project/Scripts/Utils/Definitions/StageDefinitions.cs
@@ -1,0 +1,18 @@
+﻿namespace Project.Scripts.Utils.Definitions
+{
+	public static class StageNum
+	{
+		public const int EASY = 10;
+		public const int NORMAL = 10;
+		public const int HARD = 10;
+		public const int VERY_HARD = 10;
+	}
+
+	public static class StageStartId
+	{
+		public const int EASY = 0;
+		public const int NORMAL = EASY + StageNum.EASY;
+		public const int HARD = NORMAL + StageNum.NORMAL;
+		public const int VERY_HARD = HARD + StageNum.HARD;
+	}
+}

--- a/Assets/Project/Scripts/Utils/Definitions/StageDefinitions.cs.meta
+++ b/Assets/Project/Scripts/Utils/Definitions/StageDefinitions.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 555f96f2dea24c59b6f6a28214d53341
+timeCreated: 1556778388


### PR DESCRIPTION
## 対象イシュー
https://app.mmth.pro/projects/18382/tasks#/show/230309

## 概要
`stageId`を異なる難易度で重複しない，一意のidになったので，idに合わせてステージを作ることができるようになった．

### その他
- 不要なデバックプリントを削除
- `MenuSelectScene`に名前を変更したことで起きていたバグを修正
- ステージ選択のボタンに複数のリスナーが付与されていたことで起きていたバグを修正

## 技術的な内容
- `stageId`は，`StageDefinitions`に定義されている内容に基づいて，連続的な一意のidをつける．
- 将来的な拡張性も含めて，1つの難易度に対して，1000ステージを生成できるようにナンバリング．
