### PR TITLE
銃弾の先端をパネルが擦り抜ける

### DIFF
--- a/Assets/Project/Scripts/GamePlayScene/Bullet/NormalCartridgeController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/NormalCartridgeController.cs
@@ -18,9 +18,9 @@ namespace Project.Scripts.GamePlayScene.Bullet
 			// 銃弾の先頭部分のみに当たり判定を与える
 			const float betweenPanels = TileSize.WIDTH - PanelSize.WIDTH;
 			gameObject.GetComponent<BoxCollider2D>().offset =
-				new Vector2(-(originalWidth - betweenPanels / 2) / 2, 0);
+				new Vector2(-(originalWidth - betweenPanels) / 2, 0);
 			gameObject.GetComponent<BoxCollider2D>().size =
-				new Vector2(betweenPanels / 2, originalHeight);
+				new Vector2(betweenPanels, originalHeight);
 			gameObject.GetComponent<BoxCollider2D>().isTrigger = true;
 			// RigidBodyのアタッチメント
 			gameObject.AddComponent<Rigidbody2D>();


### PR DESCRIPTION
## 対象イシュー
https://app.mmth.pro/projects/18382/tasks#/show/217271

## 概要
- 銃弾がパネルをすり抜ける問題を改善
- 銃弾の当たり判定部分の計算に間違いがあったので修正。以前の２倍の当たり判定の大きさとなった。
- 改善されたものの、依然として、当たり判定部分の大きさが、パネル間の幅よりわずかに小さい問題が残っている。

## 技術的な内容
- 不要な徐算を修正

## キャプチャ
