### PR TITLE
記録画面 (仮) の実装

### DIFF
--- a/Assets/Project/Prefabs/RecordScene.meta
+++ b/Assets/Project/Prefabs/RecordScene.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f87fd02b5794a4c5fa75a752f9f5749a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/Prefabs/RecordScene/graph.prefab
+++ b/Assets/Project/Prefabs/RecordScene/graph.prefab
@@ -23,7 +23,7 @@ GameObject:
   - component: {fileID: 114730860889979388}
   m_Layer: 5
   m_Name: graph
-  m_TagString: Untagged
+  m_TagString: GraphUi
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/Project/Prefabs/RecordScene/graph.prefab
+++ b/Assets/Project/Prefabs/RecordScene/graph.prefab
@@ -1,0 +1,81 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1622654635503194}
+  m_IsPrefabParent: 1
+--- !u!1 &1622654635503194
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 224770818493866770}
+  - component: {fileID: 222177098200801762}
+  - component: {fileID: 114730860889979388}
+  m_Layer: 5
+  m_Name: graph
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &114730860889979388
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1622654635503194}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.028301895, g: 0.027634397, b: 0.027634397, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+--- !u!222 &222177098200801762
+CanvasRenderer:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1622654635503194}
+--- !u!224 &224770818493866770
+RectTransform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1622654635503194}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 0}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.1, y: 0.15}
+  m_AnchorMax: {x: 0.2, y: 0.9}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}

--- a/Assets/Project/Prefabs/RecordScene/graph.prefab.meta
+++ b/Assets/Project/Prefabs/RecordScene/graph.prefab.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b144f6c938d114f16b8dc352d74a5d5a
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 100100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/Prefabs/RecordScene/stageNum.prefab
+++ b/Assets/Project/Prefabs/RecordScene/stageNum.prefab
@@ -23,7 +23,7 @@ GameObject:
   - component: {fileID: 114270788252170842}
   m_Layer: 5
   m_Name: stageNum
-  m_TagString: Untagged
+  m_TagString: GraphUi
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -49,7 +49,7 @@ MonoBehaviour:
       Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_FontData:
     m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
-    m_FontSize: 20
+    m_FontSize: 15
     m_FontStyle: 0
     m_BestFit: 0
     m_MinSize: 0
@@ -81,7 +81,7 @@ RectTransform:
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.1, y: 0.05}
-  m_AnchorMax: {x: 0.2, y: 0.14}
+  m_AnchorMax: {x: 0.2, y: 0.15}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}

--- a/Assets/Project/Prefabs/RecordScene/stageNum.prefab
+++ b/Assets/Project/Prefabs/RecordScene/stageNum.prefab
@@ -1,0 +1,87 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1009195855993088}
+  m_IsPrefabParent: 1
+--- !u!1 &1009195855993088
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 224684877978474630}
+  - component: {fileID: 222123269205567022}
+  - component: {fileID: 114270788252170842}
+  m_Layer: 5
+  m_Name: stageNum
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &114270788252170842
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1009195855993088}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 20
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 0
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: 1
+--- !u!222 &222123269205567022
+CanvasRenderer:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1009195855993088}
+--- !u!224 &224684877978474630
+RectTransform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1009195855993088}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.1, y: 0.05}
+  m_AnchorMax: {x: 0.2, y: 0.14}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}

--- a/Assets/Project/Prefabs/RecordScene/stageNum.prefab.meta
+++ b/Assets/Project/Prefabs/RecordScene/stageNum.prefab.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b626be635a42747f6a7fd8fb88fcc4ff
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 100100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/Prefabs/RecordScene/successLine.prefab
+++ b/Assets/Project/Prefabs/RecordScene/successLine.prefab
@@ -23,7 +23,7 @@ GameObject:
   - component: {fileID: 114735910477526540}
   m_Layer: 5
   m_Name: successLine
-  m_TagString: Untagged
+  m_TagString: GraphUi
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -40,7 +40,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0, g: 0, b: 0, a: 1}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
   m_OnCullStateChanged:
     m_PersistentCalls:

--- a/Assets/Project/Prefabs/RecordScene/successLine.prefab
+++ b/Assets/Project/Prefabs/RecordScene/successLine.prefab
@@ -1,0 +1,81 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1781992108246784}
+  m_IsPrefabParent: 1
+--- !u!1 &1781992108246784
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 224221137684433798}
+  - component: {fileID: 222786159061315908}
+  - component: {fileID: 114735910477526540}
+  m_Layer: 5
+  m_Name: successLine
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &114735910477526540
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1781992108246784}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+--- !u!222 &222786159061315908
+CanvasRenderer:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1781992108246784}
+--- !u!224 &224221137684433798
+RectTransform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1781992108246784}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 0}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.1, y: 0.15}
+  m_AnchorMax: {x: 0.95, y: 0.15}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 2}
+  m_Pivot: {x: 0.5, y: 0.5}

--- a/Assets/Project/Prefabs/RecordScene/successLine.prefab.meta
+++ b/Assets/Project/Prefabs/RecordScene/successLine.prefab.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 923a9a5e14eb54aa082f3884cb658373
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 100100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/Scenes/ConfigScene.unity
+++ b/Assets/Project/Scenes/ConfigScene.unity
@@ -484,7 +484,7 @@ GameObject:
   - component: {fileID: 102037234}
   - component: {fileID: 102037233}
   m_Layer: 5
-  m_Name: Dummy1
+  m_Name: Reset
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -501,7 +501,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 1353298367}
-  - {fileID: 357242970}
+  - {fileID: 406632796}
   m_Father: {fileID: 1600300740}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -777,6 +777,80 @@ MonoBehaviour:
     m_TypeName: UnityEngine.UI.Toggle+ToggleEvent, UnityEngine.UI, Version=1.0.0.0,
       Culture=neutral, PublicKeyToken=null
   m_IsOn: 0
+--- !u!1 &344233109
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 344233110}
+  - component: {fileID: 344233112}
+  - component: {fileID: 344233111}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &344233110
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 344233109}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 406632796}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &344233111
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 344233109}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 14
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 10
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: "\u5B9F\u884C"
+--- !u!222 &344233112
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 344233109}
 --- !u!1 &345625614
 GameObject:
   m_ObjectHideFlags: 0
@@ -928,50 +1002,64 @@ CanvasRenderer:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 347799928}
---- !u!1 &357242969
+--- !u!1 &406632795
 GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   serializedVersion: 5
   m_Component:
-  - component: {fileID: 357242970}
-  - component: {fileID: 357242971}
+  - component: {fileID: 406632796}
+  - component: {fileID: 406632800}
+  - component: {fileID: 406632799}
+  - component: {fileID: 406632798}
+  - component: {fileID: 406632797}
   m_Layer: 5
-  m_Name: Toggle
+  m_Name: Button
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!224 &357242970
+--- !u!224 &406632796
 RectTransform:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 357242969}
+  m_GameObject: {fileID: 406632795}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
-  - {fileID: 603911033}
+  - {fileID: 344233110}
   m_Father: {fileID: 102037232}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.6, y: 0.25}
-  m_AnchorMax: {x: 1, y: 0.75}
+  m_AnchorMin: {x: 0.7, y: 0.25}
+  m_AnchorMax: {x: 0.9, y: 0.75}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 1, y: 0.5}
---- !u!114 &357242971
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &406632797
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 357242969}
+  m_GameObject: {fileID: 406632795}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 2109663825, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: dabd33ef54eb84ae6892356a30edf66d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &406632798
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 406632795}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1392445389, guid: f70555f144d8491a825f0804e09c671c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Navigation:
@@ -998,16 +1086,45 @@ MonoBehaviour:
     m_PressedTrigger: Pressed
     m_DisabledTrigger: Disabled
   m_Interactable: 1
-  m_TargetGraphic: {fileID: 603911035}
-  toggleTransition: 1
-  graphic: {fileID: 937174772}
-  m_Group: {fileID: 0}
-  onValueChanged:
+  m_TargetGraphic: {fileID: 406632799}
+  m_OnClick:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.Toggle+ToggleEvent, UnityEngine.UI, Version=1.0.0.0,
+    m_TypeName: UnityEngine.UI.Button+ButtonClickedEvent, UnityEngine.UI, Version=1.0.0.0,
       Culture=neutral, PublicKeyToken=null
-  m_IsOn: 0
+--- !u!114 &406632799
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 406632795}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+--- !u!222 &406632800
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 406632795}
 --- !u!1 &430263062
 GameObject:
   m_ObjectHideFlags: 0
@@ -1711,89 +1828,6 @@ CanvasRenderer:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 560135218}
---- !u!1 &603911032
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
-  m_Component:
-  - component: {fileID: 603911033}
-  - component: {fileID: 603911036}
-  - component: {fileID: 603911035}
-  - component: {fileID: 603911034}
-  m_Layer: 5
-  m_Name: Background
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &603911033
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 603911032}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 937174771}
-  m_Father: {fileID: 357242970}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &603911034
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 603911032}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: -1254083943, guid: f70555f144d8491a825f0804e09c671c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_AspectMode: 2
-  m_AspectRatio: 1
---- !u!114 &603911035
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 603911032}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
-  m_Type: 1
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
---- !u!222 &603911036
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 603911032}
 --- !u!1 &615219667
 GameObject:
   m_ObjectHideFlags: 0
@@ -2438,74 +2472,6 @@ MonoBehaviour:
     m_TypeName: UnityEngine.UI.Toggle+ToggleEvent, UnityEngine.UI, Version=1.0.0.0,
       Culture=neutral, PublicKeyToken=null
   m_IsOn: 0
---- !u!1 &937174770
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
-  m_Component:
-  - component: {fileID: 937174771}
-  - component: {fileID: 937174773}
-  - component: {fileID: 937174772}
-  m_Layer: 5
-  m_Name: Checkmark
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &937174771
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 937174770}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 603911033}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 20, y: 20}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &937174772
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 937174770}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  m_Sprite: {fileID: 10901, guid: 0000000000000000f000000000000000, type: 0}
-  m_Type: 0
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
---- !u!222 &937174773
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 937174770}
 --- !u!1 &944988164
 GameObject:
   m_ObjectHideFlags: 0
@@ -3212,7 +3178,7 @@ MonoBehaviour:
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: "\u30C0\u30DF\u30FC1"
+  m_Text: "\u30B9\u30C6\u30FC\u30B8\u30EA\u30BB\u30C3\u30C8"
 --- !u!222 &1353298369
 CanvasRenderer:
   m_ObjectHideFlags: 0

--- a/Assets/Project/Scenes/MenuSelectScene.unity
+++ b/Assets/Project/Scenes/MenuSelectScene.unity
@@ -1196,7 +1196,7 @@ RectTransform:
   m_GameObject: {fileID: 1609151025}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 0.1, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 0}
   m_Children:
   - {fileID: 1918609509}
   - {fileID: 786519703}
@@ -1206,7 +1206,7 @@ RectTransform:
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
+  m_AnchorMax: {x: 1, y: 0.1}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0}

--- a/Assets/Project/Scenes/RecordScene.unity
+++ b/Assets/Project/Scenes/RecordScene.unity
@@ -113,6 +113,80 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1 &758960182
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 758960183}
+  - component: {fileID: 758960185}
+  - component: {fileID: 758960184}
+  m_Layer: 5
+  m_Name: Percentage
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &758960183
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 758960182}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 0}
+  m_Children: []
+  m_Father: {fileID: 2136668780}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.6}
+  m_AnchorMax: {x: 1, y: 0.85}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &758960184
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 758960182}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 60
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 0
+    m_MaxSize: 60
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: 50%
+--- !u!222 &758960185
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 758960182}
 --- !u!1 &1383753165
 GameObject:
   m_ObjectHideFlags: 0
@@ -194,6 +268,148 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1809856843
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1809856844}
+  - component: {fileID: 1809856846}
+  - component: {fileID: 1809856845}
+  m_Layer: 5
+  m_Name: GraphArea
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1809856844
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1809856843}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 2136668780}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.1}
+  m_AnchorMax: {x: 1, y: 0.6}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1809856845
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1809856843}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.392}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+--- !u!222 &1809856846
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1809856843}
+--- !u!1 &2031290133
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 2031290134}
+  - component: {fileID: 2031290136}
+  - component: {fileID: 2031290135}
+  m_Layer: 5
+  m_Name: Level
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2031290134
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2031290133}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 0}
+  m_Children: []
+  m_Father: {fileID: 2136668780}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.25, y: 0.85}
+  m_AnchorMax: {x: 0.75, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &2031290135
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2031290133}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 40
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 0
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Level
+--- !u!222 &2031290136
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2031290133}
 --- !u!1 &2136668776
 GameObject:
   m_ObjectHideFlags: 0
@@ -278,7 +494,10 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0, y: 0, z: 0}
-  m_Children: []
+  m_Children:
+  - {fileID: 2031290134}
+  - {fileID: 758960183}
+  - {fileID: 1809856844}
   m_Father: {fileID: 0}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Project/Scenes/RecordScene.unity
+++ b/Assets/Project/Scenes/RecordScene.unity
@@ -194,80 +194,6 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1885551836
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
-  m_Component:
-  - component: {fileID: 1885551837}
-  - component: {fileID: 1885551839}
-  - component: {fileID: 1885551838}
-  m_Layer: 5
-  m_Name: Text
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &1885551837
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1885551836}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 0.9, z: 1}
-  m_Children: []
-  m_Father: {fileID: 2136668780}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0.5, y: 1}
---- !u!114 &1885551838
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1885551836}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
-  m_RaycastTarget: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  m_FontData:
-    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
-    m_FontSize: 30
-    m_FontStyle: 0
-    m_BestFit: 0
-    m_MinSize: 0
-    m_MaxSize: 40
-    m_Alignment: 4
-    m_AlignByGeometry: 0
-    m_RichText: 1
-    m_HorizontalOverflow: 0
-    m_VerticalOverflow: 0
-    m_LineSpacing: 1
-  m_Text: "\u8A18\u9332"
---- !u!222 &1885551839
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1885551836}
 --- !u!1 &2136668776
 GameObject:
   m_ObjectHideFlags: 0
@@ -352,8 +278,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0, y: 0, z: 0}
-  m_Children:
-  - {fileID: 1885551837}
+  m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Project/Scenes/RecordScene.unity
+++ b/Assets/Project/Scenes/RecordScene.unity
@@ -433,7 +433,7 @@ MonoBehaviour:
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: 2
+  m_Text: 20
 --- !u!222 &271401622
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -507,7 +507,7 @@ MonoBehaviour:
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: 3
+  m_Text: 30
 --- !u!222 &417108012
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -1060,7 +1060,7 @@ MonoBehaviour:
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: 1
+  m_Text: 10
 --- !u!222 &1664818851
 CanvasRenderer:
   m_ObjectHideFlags: 0

--- a/Assets/Project/Scenes/RecordScene.unity
+++ b/Assets/Project/Scenes/RecordScene.unity
@@ -217,7 +217,7 @@ RectTransform:
   m_Children:
   - {fileID: 1585252303}
   m_Father: {fileID: 2136668780}
-  m_RootOrder: 3
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.8, y: 0.875}
   m_AnchorMax: {x: 0.95, y: 0.975}
@@ -284,7 +284,7 @@ MonoBehaviour:
       m_Calls: []
     m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
       Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  m_Sprite: {fileID: 21300000, guid: 5410db89f39a24e0fa785adf88e19b01, type: 3}
+  m_Sprite: {fileID: 21300000, guid: b0081e359adba4495b37de176597ae07, type: 3}
   m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1
@@ -659,14 +659,14 @@ RectTransform:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1854890890}
-  m_LocalRotation: {x: 0, y: 1, z: 0, w: 0}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 0}
   m_Children:
   - {fileID: 27399440}
   m_Father: {fileID: 2136668780}
-  m_RootOrder: 4
-  m_LocalEulerAnglesHint: {x: 0, y: 180, z: 0}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.05, y: 0.875}
   m_AnchorMax: {x: 0.2, y: 0.975}
   m_AnchoredPosition: {x: 0, y: 0}
@@ -732,7 +732,7 @@ MonoBehaviour:
       m_Calls: []
     m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
       Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  m_Sprite: {fileID: 21300000, guid: 5410db89f39a24e0fa785adf88e19b01, type: 3}
+  m_Sprite: {fileID: 21300000, guid: 2b3fba1172beb421ca58c3f3e8f627cc, type: 3}
   m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1
@@ -908,8 +908,8 @@ RectTransform:
   - {fileID: 2031290134}
   - {fileID: 758960183}
   - {fileID: 1809856844}
-  - {fileID: 69869801}
   - {fileID: 1854890891}
+  - {fileID: 69869801}
   m_Father: {fileID: 0}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Project/Scenes/RecordScene.unity
+++ b/Assets/Project/Scenes/RecordScene.unity
@@ -849,6 +849,8 @@ MonoBehaviour:
     type: 2}
   stageNumPrefab: {fileID: 1009195855993088, guid: b626be635a42747f6a7fd8fb88fcc4ff,
     type: 2}
+  successLinePrefab: {fileID: 1781992108246784, guid: 923a9a5e14eb54aa082f3884cb658373,
+    type: 2}
 --- !u!1 &1572766962
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Project/Scenes/RecordScene.unity
+++ b/Assets/Project/Scenes/RecordScene.unity
@@ -453,6 +453,46 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1569154215
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1569154216}
+  - component: {fileID: 1569154217}
+  m_Layer: 0
+  m_Name: RecordDirector
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1569154216
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1569154215}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -227.5005, y: 448.11093, z: -10.744464}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1569154217
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1569154215}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d4b53763965784e018406592f8845568, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1585252302
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Project/Scenes/RecordScene.unity
+++ b/Assets/Project/Scenes/RecordScene.unity
@@ -433,7 +433,7 @@ MonoBehaviour:
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: 1000
+  m_Text: 2
 --- !u!222 &271401622
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -507,7 +507,7 @@ MonoBehaviour:
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: 1500
+  m_Text: 3
 --- !u!222 &417108012
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -1060,7 +1060,7 @@ MonoBehaviour:
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: 500
+  m_Text: 1
 --- !u!222 &1664818851
 CanvasRenderer:
   m_ObjectHideFlags: 0

--- a/Assets/Project/Scenes/RecordScene.unity
+++ b/Assets/Project/Scenes/RecordScene.unity
@@ -493,6 +493,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d4b53763965784e018406592f8845568, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  graphPrefab: {fileID: 1622654635503194, guid: b144f6c938d114f16b8dc352d74a5d5a,
+    type: 2}
+  stageNumPrefab: {fileID: 1009195855993088, guid: b626be635a42747f6a7fd8fb88fcc4ff,
+    type: 2}
 --- !u!1 &1585252302
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Project/Scenes/RecordScene.unity
+++ b/Assets/Project/Scenes/RecordScene.unity
@@ -113,6 +113,74 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1 &12404793
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 12404794}
+  - component: {fileID: 12404796}
+  - component: {fileID: 12404795}
+  m_Layer: 5
+  m_Name: Scale2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &12404794
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 12404793}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 0}
+  m_Children: []
+  m_Father: {fileID: 1809856844}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.1, y: 0.4}
+  m_AnchorMax: {x: 0.95, y: 0.4}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 1}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &12404795
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 12404793}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.39215687, g: 0.39215687, b: 0.39215687, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+--- !u!222 &12404796
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 12404793}
 --- !u!1 &27399439
 GameObject:
   m_ObjectHideFlags: 0
@@ -298,6 +366,222 @@ CanvasRenderer:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 69869800}
+--- !u!1 &271401619
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 271401620}
+  - component: {fileID: 271401622}
+  - component: {fileID: 271401621}
+  m_Layer: 5
+  m_Name: Scale3-Value
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &271401620
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 271401619}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 0}
+  m_Children: []
+  m_Father: {fileID: 1809856844}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.6}
+  m_AnchorMax: {x: 0.1, y: 0.7}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &271401621
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 271401619}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 12
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 1
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: 1000
+--- !u!222 &271401622
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 271401619}
+--- !u!1 &417108009
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 417108010}
+  - component: {fileID: 417108012}
+  - component: {fileID: 417108011}
+  m_Layer: 5
+  m_Name: Scale4-Value
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &417108010
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 417108009}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 0}
+  m_Children: []
+  m_Father: {fileID: 1809856844}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.85}
+  m_AnchorMax: {x: 0.1, y: 0.95}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &417108011
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 417108009}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 12
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 1
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: 1500
+--- !u!222 &417108012
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 417108009}
+--- !u!1 &664554980
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 664554981}
+  - component: {fileID: 664554983}
+  - component: {fileID: 664554982}
+  m_Layer: 5
+  m_Name: Scale4
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &664554981
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 664554980}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 0}
+  m_Children: []
+  m_Father: {fileID: 1809856844}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.1, y: 0.9}
+  m_AnchorMax: {x: 0.95, y: 0.9}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 1}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &664554982
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 664554980}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.39215687, g: 0.39215687, b: 0.39215687, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+--- !u!222 &664554983
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 664554980}
 --- !u!1 &758960182
 GameObject:
   m_ObjectHideFlags: 0
@@ -372,6 +656,74 @@ CanvasRenderer:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 758960182}
+--- !u!1 &1093850367
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1093850368}
+  - component: {fileID: 1093850370}
+  - component: {fileID: 1093850369}
+  m_Layer: 5
+  m_Name: Y-Axis
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1093850368
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1093850367}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1809856844}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.1, y: 0.15}
+  m_AnchorMax: {x: 0.1, y: 0.95}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 1, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1093850369
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1093850367}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.39215687, g: 0.39215687, b: 0.39215687, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+--- !u!222 &1093850370
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1093850367}
 --- !u!1 &1383753165
 GameObject:
   m_ObjectHideFlags: 0
@@ -497,6 +849,74 @@ MonoBehaviour:
     type: 2}
   stageNumPrefab: {fileID: 1009195855993088, guid: b626be635a42747f6a7fd8fb88fcc4ff,
     type: 2}
+--- !u!1 &1572766962
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1572766963}
+  - component: {fileID: 1572766965}
+  - component: {fileID: 1572766964}
+  m_Layer: 5
+  m_Name: Scale1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1572766963
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1572766962}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 0}
+  m_Children: []
+  m_Father: {fileID: 1809856844}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.1, y: 0.15}
+  m_AnchorMax: {x: 0.95, y: 0.15}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 1}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1572766964
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1572766962}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.39215687, g: 0.39215687, b: 0.39215687, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+--- !u!222 &1572766965
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1572766962}
 --- !u!1 &1585252302
 GameObject:
   m_ObjectHideFlags: 0
@@ -571,6 +991,80 @@ CanvasRenderer:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1585252302}
+--- !u!1 &1664818848
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1664818849}
+  - component: {fileID: 1664818851}
+  - component: {fileID: 1664818850}
+  m_Layer: 5
+  m_Name: Scale2-Value
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1664818849
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1664818848}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 0}
+  m_Children: []
+  m_Father: {fileID: 1809856844}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.35}
+  m_AnchorMax: {x: 0.1, y: 0.45}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1664818850
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1664818848}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 12
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 1
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: 500
+--- !u!222 &1664818851
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1664818848}
 --- !u!1 &1809856843
 GameObject:
   m_ObjectHideFlags: 0
@@ -597,7 +1091,16 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 0}
-  m_Children: []
+  m_Children:
+  - {fileID: 1093850368}
+  - {fileID: 664554981}
+  - {fileID: 1950187095}
+  - {fileID: 12404794}
+  - {fileID: 1572766963}
+  - {fileID: 417108010}
+  - {fileID: 271401620}
+  - {fileID: 1664818849}
+  - {fileID: 2006657901}
   m_Father: {fileID: 2136668780}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -750,6 +1253,148 @@ CanvasRenderer:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1854890890}
+--- !u!1 &1950187094
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1950187095}
+  - component: {fileID: 1950187097}
+  - component: {fileID: 1950187096}
+  m_Layer: 5
+  m_Name: Scale3
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1950187095
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1950187094}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 0}
+  m_Children: []
+  m_Father: {fileID: 1809856844}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.1, y: 0.65}
+  m_AnchorMax: {x: 0.95, y: 0.65}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 1}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1950187096
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1950187094}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.39215687, g: 0.39215687, b: 0.39215687, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+--- !u!222 &1950187097
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1950187094}
+--- !u!1 &2006657900
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 2006657901}
+  - component: {fileID: 2006657903}
+  - component: {fileID: 2006657902}
+  m_Layer: 5
+  m_Name: Scale1-Value
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2006657901
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2006657900}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1809856844}
+  m_RootOrder: 8
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.1}
+  m_AnchorMax: {x: 0.1, y: 0.2}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &2006657902
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2006657900}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 12
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 1
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: 0
+--- !u!222 &2006657903
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2006657900}
 --- !u!1 &2031290133
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Project/Scenes/RecordScene.unity
+++ b/Assets/Project/Scenes/RecordScene.unity
@@ -113,6 +113,191 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1 &27399439
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 27399440}
+  - component: {fileID: 27399442}
+  - component: {fileID: 27399441}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &27399440
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 27399439}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1854890891}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &27399441
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 27399439}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 14
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 10
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: 
+--- !u!222 &27399442
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 27399439}
+--- !u!1 &69869800
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 69869801}
+  - component: {fileID: 69869804}
+  - component: {fileID: 69869803}
+  - component: {fileID: 69869802}
+  m_Layer: 5
+  m_Name: RightButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &69869801
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 69869800}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 0}
+  m_Children:
+  - {fileID: 1585252303}
+  m_Father: {fileID: 2136668780}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.8, y: 0.875}
+  m_AnchorMax: {x: 0.95, y: 0.975}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &69869802
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 69869800}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1392445389, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 69869803}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.Button+ButtonClickedEvent, UnityEngine.UI, Version=1.0.0.0,
+      Culture=neutral, PublicKeyToken=null
+--- !u!114 &69869803
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 69869800}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 21300000, guid: 5410db89f39a24e0fa785adf88e19b01, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+--- !u!222 &69869804
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 69869800}
 --- !u!1 &758960182
 GameObject:
   m_ObjectHideFlags: 0
@@ -268,6 +453,80 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1585252302
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1585252303}
+  - component: {fileID: 1585252305}
+  - component: {fileID: 1585252304}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1585252303
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1585252302}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 69869801}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1585252304
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1585252302}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 14
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 10
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: 
+--- !u!222 &1585252305
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1585252302}
 --- !u!1 &1809856843
 GameObject:
   m_ObjectHideFlags: 0
@@ -336,6 +595,117 @@ CanvasRenderer:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1809856843}
+--- !u!1 &1854890890
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1854890891}
+  - component: {fileID: 1854890894}
+  - component: {fileID: 1854890893}
+  - component: {fileID: 1854890892}
+  m_Layer: 5
+  m_Name: LeftButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1854890891
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1854890890}
+  m_LocalRotation: {x: 0, y: 1, z: 0, w: 0}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 0}
+  m_Children:
+  - {fileID: 27399440}
+  m_Father: {fileID: 2136668780}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 180, z: 0}
+  m_AnchorMin: {x: 0.05, y: 0.875}
+  m_AnchorMax: {x: 0.2, y: 0.975}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1854890892
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1854890890}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1392445389, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1854890893}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.Button+ButtonClickedEvent, UnityEngine.UI, Version=1.0.0.0,
+      Culture=neutral, PublicKeyToken=null
+--- !u!114 &1854890893
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1854890890}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 21300000, guid: 5410db89f39a24e0fa785adf88e19b01, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+--- !u!222 &1854890894
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1854890890}
 --- !u!1 &2031290133
 GameObject:
   m_ObjectHideFlags: 0
@@ -498,6 +868,8 @@ RectTransform:
   - {fileID: 2031290134}
   - {fileID: 758960183}
   - {fileID: 1809856844}
+  - {fileID: 69869801}
+  - {fileID: 1854890891}
   m_Father: {fileID: 0}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Project/Scenes/RecordScene.unity
+++ b/Assets/Project/Scenes/RecordScene.unity
@@ -552,7 +552,7 @@ RectTransform:
   m_GameObject: {fileID: 1809856843}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalScale: {x: 1, y: 1, z: 0}
   m_Children: []
   m_Father: {fileID: 2136668780}
   m_RootOrder: 2

--- a/Assets/Project/Scripts/ConfigScene/ResetController.cs
+++ b/Assets/Project/Scripts/ConfigScene/ResetController.cs
@@ -18,14 +18,17 @@ namespace Project.Scripts.ConfigScene
 
 		private static void ResetButtonDown()
 		{
-			ResetStageStatus(StageNum.EASY, StageStartId.EASY);
-			ResetStageStatus(StageNum.NORMAL, StageStartId.NORMAL);
-			ResetStageStatus(StageNum.HARD, StageStartId.HARD);
-			ResetStageStatus(StageNum.VERY_HARD, StageStartId.VERY_HARD);
+			ResetStageStatus(StageLevel.Easy);
+			ResetStageStatus(StageLevel.Normal);
+			ResetStageStatus(StageLevel.Hard);
+			ResetStageStatus(StageLevel.VeryHard);
 		}
 
-		private static void ResetStageStatus(int stageNum, int stageStartId)
+		private static void ResetStageStatus(StageLevel stageLevel)
 		{
+			var stageNum = StageInfo.Num[stageLevel];
+			var stageStartId = StageInfo.StageStartId[stageLevel];
+
 			for (var stageId = stageStartId; stageId < stageStartId + stageNum; stageId++)
 			{
 				StageStatus.Reset(stageId);

--- a/Assets/Project/Scripts/ConfigScene/ResetController.cs
+++ b/Assets/Project/Scripts/ConfigScene/ResetController.cs
@@ -1,0 +1,35 @@
+﻿using Project.Scripts.Utils.Definitions;
+using Project.Scripts.Utils.PlayerPrefsUtils;
+using UnityEngine;
+using UnityEngine.UI;
+
+
+namespace Project.Scripts.ConfigScene
+{
+	public class ResetController : MonoBehaviour
+	{
+		private Button resetButton;
+
+		private void Awake()
+		{
+			resetButton = GetComponent<Button>();
+			resetButton.onClick.AddListener(ResetButtonDown);
+		}
+
+		private static void ResetButtonDown()
+		{
+			ResetStageStatus(StageNum.EASY, StageStartId.EASY);
+			ResetStageStatus(StageNum.NORMAL, StageStartId.NORMAL);
+			ResetStageStatus(StageNum.HARD, StageStartId.HARD);
+			ResetStageStatus(StageNum.VERY_HARD, StageStartId.VERY_HARD);
+		}
+
+		private static void ResetStageStatus(int stageNum, int stageStartId)
+		{
+			for (var stageId = stageStartId; stageId < stageStartId + stageNum; stageId++)
+			{
+				StageStatus.Reset(stageId);
+			}
+		}
+	}
+}

--- a/Assets/Project/Scripts/ConfigScene/ResetController.cs.meta
+++ b/Assets/Project/Scripts/ConfigScene/ResetController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: dabd33ef54eb84ae6892356a30edf66d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/Scripts/GamePlayScene/StageGenerator.cs
+++ b/Assets/Project/Scripts/GamePlayScene/StageGenerator.cs
@@ -117,6 +117,39 @@ namespace Project.Scripts.GamePlayScene
 					panelGenerator.CreateNumberPanel(panelNum: 7, initialTileNum: 13, finalTileNum: 10);
 					panelGenerator.CreateNumberPanel(panelNum: 8, initialTileNum: 15, finalTileNum: 11);
 					break;
+				// 記録画面テスト用 (`case 1`と全く同じ)
+				case 1001:
+					// 銃弾実体生成
+					coroutines.Add(bulletGenerator.CreateCartridge(
+						cartridgeType: CartridgeType.Turn,
+						appearanceTime: 1.0f,
+						interval: 1.0f,
+						direction: CartridgeDirection.ToLeft,
+						line: (int) Row.Second,
+						loop: true,
+						additionalInfo: BulletGenerator.SetTurnCartridgeInfo(
+							turnDirection: new[] {(int) CartridgeDirection.ToUp, (int) CartridgeDirection.ToLeft},
+							turnLine: new[] {(int) Column.Right, (int) Row.First})));
+					coroutines.Add(bulletGenerator.CreateCartridge(
+						cartridgeType: CartridgeType.Normal,
+						direction: CartridgeDirection.ToUp,
+						line: (int) Column.Right,
+						appearanceTime: 2.0f,
+						interval: 4.0f));
+					// タイル作成
+					tileGenerator.CreateNormalTiles();
+					// パネル作成
+					panelGenerator.CreateDynamicDummyPanel(initialTileNum: 3);
+					panelGenerator.CreateNumberPanel(panelNum: 1, initialTileNum: 4, finalTileNum: 4);
+					panelGenerator.CreateNumberPanel(panelNum: 2, initialTileNum: 5, finalTileNum: 5);
+					panelGenerator.CreateNumberPanel(panelNum: 3, initialTileNum: 6, finalTileNum: 6);
+					panelGenerator.CreateNumberPanel(panelNum: 4, initialTileNum: 7, finalTileNum: 7);
+					panelGenerator.CreateNumberPanel(panelNum: 5, initialTileNum: 8, finalTileNum: 8);
+					panelGenerator.CreateNumberPanel(panelNum: 6, initialTileNum: 9, finalTileNum: 9);
+					panelGenerator.CreateNumberPanel(panelNum: 7, initialTileNum: 10, finalTileNum: 10);
+					panelGenerator.CreateNumberPanel(panelNum: 8, initialTileNum: 14, finalTileNum: 11);
+					panelGenerator.CreateStaticDummyPanel(initialTileNum: 15);
+					break;
 				default:
 					throw new NotImplementedException();
 			}

--- a/Assets/Project/Scripts/GamePlayScene/Tile/NormalTileController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Tile/NormalTileController.cs
@@ -35,6 +35,7 @@ namespace Project.Scripts.GamePlayScene.Tile
 			{
 				return gameObject;
 			}
+
 			return null;
 		}
 

--- a/Assets/Project/Scripts/RecordScene.meta
+++ b/Assets/Project/Scripts/RecordScene.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f16f54cd7e74343929d3bb3757fc6d4f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/Scripts/RecordScene/RecordDirector.cs
+++ b/Assets/Project/Scripts/RecordScene/RecordDirector.cs
@@ -90,7 +90,7 @@ namespace Project.Scripts.RecordScene
 		{
 			var successStageNum = 0;
 
-			for (var stageId = stageStartId; stageId < stageStartId + stageNum ; stageId++)
+			for (var stageId = stageStartId; stageId < stageStartId + stageNum; stageId++)
 			{
 				var stageStatus = StageStatus.Get(stageId);
 
@@ -110,7 +110,7 @@ namespace Project.Scripts.RecordScene
 		{
 			// 挑戦回数の最大値を求める
 			var maxChallengeNum = 0;
-			for (var stageId = stageStartId; stageId < stageStartId + stageNum ; stageId++)
+			for (var stageId = stageStartId; stageId < stageStartId + stageNum; stageId++)
 			{
 				var stageStatus = StageStatus.Get(stageId);
 
@@ -130,7 +130,8 @@ namespace Project.Scripts.RecordScene
 			}
 
 			// 描画する範囲
-			var graphAreaContent = graphArea.GetComponent<RectTransform>();;
+			var graphAreaContent = graphArea.GetComponent<RectTransform>();
+			;
 			// 隙間の大きさ
 			var blankWidth = 0.85f / ((1 + RATIO_GRAPH_SPACE) * stageNum + 1);
 			// グラフの横幅
@@ -148,7 +149,7 @@ namespace Project.Scripts.RecordScene
 			// ステージ番号
 			var stageName = 1;
 
-			for (var stageId = stageStartId; stageId < stageStartId + stageNum ; stageId++)
+			for (var stageId = stageStartId; stageId < stageStartId + stageNum; stageId++)
 			{
 				var stageStatus = StageStatus.Get(stageId);
 
@@ -159,7 +160,8 @@ namespace Project.Scripts.RecordScene
 				stageNumUi.transform.SetParent(graphAreaContent, false);
 				stageNumUi.GetComponent<Text>().text = stageName.ToString();
 				stageNumUi.GetComponent<RectTransform>().anchorMin = new Vector2(leftPosition, bottomStageNumPosition);
-				stageNumUi.GetComponent<RectTransform>().anchorMax = new Vector2(leftPosition + graphWidth, bottomGraphPosition);
+				stageNumUi.GetComponent<RectTransform>().anchorMax =
+					new Vector2(leftPosition + graphWidth, bottomGraphPosition);
 
 				/* グラフ本体の配置 */
 				var graphUi = Instantiate(graphPrefab);
@@ -168,10 +170,11 @@ namespace Project.Scripts.RecordScene
 				// 挑戦回数に応じたグラフの高さ
 				var maxY = bottomGraphPosition;
 
-				if(maxChallengeNum != 0)
+				if (maxChallengeNum != 0)
 				{
 					// 挑戦回数に関して，グラフ本体の描画範囲に正規化する
-					maxY = (topGraphPosition - bottomGraphPosition) * stageStatus.challengeNum / maxScale + bottomGraphPosition;
+					maxY = (topGraphPosition - bottomGraphPosition) * stageStatus.challengeNum / maxScale +
+					       bottomGraphPosition;
 				}
 
 				graphUi.GetComponent<RectTransform>().anchorMin = new Vector2(leftPosition, bottomGraphPosition);
@@ -183,10 +186,12 @@ namespace Project.Scripts.RecordScene
 					graphUi.GetComponent<Image>().color = Color.cyan;
 
 					var successLineUi = Instantiate(successLinePrefab);
-					var successY = (topGraphPosition - bottomGraphPosition) * stageStatus.firstSuccessNum / maxScale + bottomGraphPosition;
+					var successY = (topGraphPosition - bottomGraphPosition) * stageStatus.firstSuccessNum / maxScale +
+					               bottomGraphPosition;
 					successLineUi.transform.SetParent(graphAreaContent, false);
 					successLineUi.GetComponent<RectTransform>().anchorMin = new Vector2(leftPosition, successY);
-					successLineUi.GetComponent<RectTransform>().anchorMax = new Vector2(leftPosition + graphWidth, successY);
+					successLineUi.GetComponent<RectTransform>().anchorMax =
+						new Vector2(leftPosition + graphWidth, successY);
 				}
 				else
 				{

--- a/Assets/Project/Scripts/RecordScene/RecordDirector.cs
+++ b/Assets/Project/Scripts/RecordScene/RecordDirector.cs
@@ -155,17 +155,16 @@ namespace Project.Scripts.RecordScene
 
 			// ステージ番号
 			var stageName = 1;
-
-			// 描画する棒グラフの左端と右端を示す
+			// 描画する棒グラフの左端を示す
 			var left = leftPosition;
 
 			for (var stageId = stageStartId; stageId < stageStartId + stageNum; stageId++)
 			{
-				var stageStatus = StageStatus.Get(stageId);
-
 				// 左端と右端の更新
 				left += blankWidth;
 				var right = left + graphWidth;
+				
+				var stageStatus = StageStatus.Get(stageId);
 
 				/* ステージ番号の配置 */
 				var stageNumUi = Instantiate(stageNumPrefab);
@@ -210,7 +209,6 @@ namespace Project.Scripts.RecordScene
 
 				// 左端の更新
 				left = right;
-
 				// ステージ番号の更新
 				stageName++;
 			}

--- a/Assets/Project/Scripts/RecordScene/RecordDirector.cs
+++ b/Assets/Project/Scripts/RecordScene/RecordDirector.cs
@@ -144,6 +144,7 @@ namespace Project.Scripts.RecordScene
 					maxY = 0.75f * stageStatus.challengeNum / maxScale + 0.15f;
 				}
 				graphUi.GetComponent<RectTransform>().anchorMax = new Vector2(leftPosition + blank, maxY);
+				graphUi.GetComponent<Image>().color = stageStatus.passed ? Color.cyan : Color.red;
 
 				var stageNumUi = Instantiate(stageNumPrefab);
 				stageNumUi.transform.SetParent(graphAreaContent, false);

--- a/Assets/Project/Scripts/RecordScene/RecordDirector.cs
+++ b/Assets/Project/Scripts/RecordScene/RecordDirector.cs
@@ -14,9 +14,9 @@ namespace Project.Scripts.RecordScene
 
 		public GameObject successLinePrefab;
 
-		private GameObject level;
+		private GameObject levelText;
 
-		private GameObject percentage;
+		private GameObject percentageText;
 
 		private GameObject graphArea;
 
@@ -28,8 +28,8 @@ namespace Project.Scripts.RecordScene
 
 		private void Awake()
 		{
-			level = GameObject.Find("Level");
-			percentage = GameObject.Find("Percentage");
+			levelText = GameObject.Find("Level");
+			percentageText = GameObject.Find("Percentage");
 			graphArea = GameObject.Find("GraphArea");
 			leftButton = GameObject.Find("LeftButton");
 			rightButton = GameObject.Find("RightButton");
@@ -57,22 +57,22 @@ namespace Project.Scripts.RecordScene
 			switch (nowLevel)
 			{
 				case StageLevel.Easy:
-					level.GetComponent<Text>().text = "Easy";
+					levelText.GetComponent<Text>().text = "Easy";
 					DrawPercentage(StageLevel.Easy);
 					DrawGraph(StageLevel.Easy);
 					break;
 				case StageLevel.Normal:
-					level.GetComponent<Text>().text = "Normal";
+					levelText.GetComponent<Text>().text = "Normal";
 					DrawPercentage(StageLevel.Normal);
 					DrawGraph(StageLevel.Normal);
 					break;
 				case StageLevel.Hard:
-					level.GetComponent<Text>().text = "Hard";
+					levelText.GetComponent<Text>().text = "Hard";
 					DrawPercentage(StageLevel.Hard);
 					DrawGraph(StageLevel.Hard);
 					break;
 				case StageLevel.VeryHard:
-					level.GetComponent<Text>().text = "VeryHard";
+					levelText.GetComponent<Text>().text = "VeryHard";
 					DrawPercentage(StageLevel.VeryHard);
 					DrawGraph(StageLevel.VeryHard);
 					break;
@@ -99,9 +99,9 @@ namespace Project.Scripts.RecordScene
 				}
 			}
 
-			var percentageNum = (successStageNum / (float) stageNum) * 100;
+			var successPercentage = (successStageNum / (float) stageNum) * 100;
 
-			percentage.GetComponent<Text>().text = percentageNum + "%";
+			percentageText.GetComponent<Text>().text = successPercentage + "%";
 		}
 
 		/* 難易度に合わせた棒グラフを描画する */
@@ -163,7 +163,7 @@ namespace Project.Scripts.RecordScene
 				// 左端と右端の更新
 				left += blankWidth;
 				var right = left + graphWidth;
-				
+
 				var stageStatus = StageStatus.Get(stageId);
 
 				/* ステージ番号の配置 */

--- a/Assets/Project/Scripts/RecordScene/RecordDirector.cs
+++ b/Assets/Project/Scripts/RecordScene/RecordDirector.cs
@@ -127,9 +127,12 @@ namespace Project.Scripts.RecordScene
 
 			// 目盛の数値を書き換える
 			var maxScale = (float) Math.Ceiling(maxChallengeNum / 3.0f) * 3.0f;
-			GameObject.Find("Scale2-Value").GetComponent<Text>().text = (maxScale / 3).ToString();
-			GameObject.Find("Scale3-Value").GetComponent<Text>().text = (maxScale * 2 / 3).ToString();
-			GameObject.Find("Scale4-Value").GetComponent<Text>().text = maxScale.ToString();
+			if (maxScale != 0)
+			{
+				GameObject.Find("Scale2-Value").GetComponent<Text>().text = (maxScale / 3).ToString();
+				GameObject.Find("Scale3-Value").GetComponent<Text>().text = (maxScale * 2 / 3).ToString();
+				GameObject.Find("Scale4-Value").GetComponent<Text>().text = maxScale.ToString();
+			}
 
 			for (var stageId = stageStartId; stageId < stageStartId + stageNum ; stageId++)
 			{

--- a/Assets/Project/Scripts/RecordScene/RecordDirector.cs
+++ b/Assets/Project/Scripts/RecordScene/RecordDirector.cs
@@ -12,6 +12,8 @@ namespace Project.Scripts.RecordScene
 
 		public GameObject stageNumPrefab;
 
+		public GameObject successLinePrefab;
+
 		private GameObject level;
 
 		private GameObject percentage;
@@ -144,7 +146,20 @@ namespace Project.Scripts.RecordScene
 					maxY = 0.75f * stageStatus.challengeNum / maxScale + 0.15f;
 				}
 				graphUi.GetComponent<RectTransform>().anchorMax = new Vector2(leftPosition + blank, maxY);
-				graphUi.GetComponent<Image>().color = stageStatus.passed ? Color.cyan : Color.red;
+
+				if (stageStatus.passed)
+				{
+					graphUi.GetComponent<Image>().color = Color.cyan;
+					var successY = 0.75f * stageStatus.firstSuccessNum / maxScale + 0.15f;
+					var successLineUi = Instantiate(successLinePrefab);
+					successLineUi.transform.SetParent(graphAreaContent, false);
+					successLineUi.GetComponent<RectTransform>().anchorMin = new Vector2(leftPosition, successY);
+					successLineUi.GetComponent<RectTransform>().anchorMax = new Vector2(leftPosition + blank, successY);
+				}
+				else
+				{
+					graphUi.GetComponent<Image>().color = Color.red;
+				}
 
 				var stageNumUi = Instantiate(stageNumPrefab);
 				stageNumUi.transform.SetParent(graphAreaContent, false);

--- a/Assets/Project/Scripts/RecordScene/RecordDirector.cs
+++ b/Assets/Project/Scripts/RecordScene/RecordDirector.cs
@@ -42,6 +42,13 @@ namespace Project.Scripts.RecordScene
 		/* 難易度に合わせた画面を描画する */
 		private void Draw(int levelNum)
 		{
+			// 画面を綺麗にする
+			GameObject[] graphUis = GameObject.FindGameObjectsWithTag(TagName.GRAPH_UI);
+			foreach (var graphUi in graphUis)
+			{
+				Destroy(graphUi);
+			}
+
 			switch (levelNum)
 			{
 				case 0:

--- a/Assets/Project/Scripts/RecordScene/RecordDirector.cs
+++ b/Assets/Project/Scripts/RecordScene/RecordDirector.cs
@@ -24,7 +24,7 @@ namespace Project.Scripts.RecordScene
 
 		private GameObject rightButton;
 
-		private int nowLevel;
+		private StageLevel nowLevel;
 
 		private void Awake()
 		{
@@ -42,7 +42,7 @@ namespace Project.Scripts.RecordScene
 		}
 
 		/* 難易度に合わせた画面を描画する */
-		private void Draw(int levelNum)
+		private void Draw(StageLevel stageLevel)
 		{
 			// 画面を綺麗にする
 			GameObject[] graphUis = GameObject.FindGameObjectsWithTag(TagName.GRAPH_UI);
@@ -51,31 +51,30 @@ namespace Project.Scripts.RecordScene
 				Destroy(graphUi);
 			}
 
-			switch (levelNum)
+			// 難易度の更新
+			nowLevel = stageLevel;
+
+			switch (nowLevel)
 			{
-				case 0:
-					nowLevel = 0;
+				case StageLevel.Easy:
 					level.GetComponent<Text>().text = "Easy";
-					DrawPercentage(StageNum.EASY, StageStartId.EASY);
-					DrawGraph(StageNum.EASY, StageStartId.EASY);
+					DrawPercentage(StageLevel.Easy);
+					DrawGraph(StageLevel.Easy);
 					break;
-				case 1:
-					nowLevel = 1;
+				case StageLevel.Normal:
 					level.GetComponent<Text>().text = "Normal";
-					DrawPercentage(StageNum.NORMAL, StageStartId.NORMAL);
-					DrawGraph(StageNum.NORMAL, StageStartId.NORMAL);
+					DrawPercentage(StageLevel.Normal);
+					DrawGraph(StageLevel.Normal);
 					break;
-				case 2:
-					nowLevel = 2;
+				case StageLevel.Hard:
 					level.GetComponent<Text>().text = "Hard";
-					DrawPercentage(StageNum.HARD, StageStartId.HARD);
-					DrawGraph(StageNum.HARD, StageStartId.HARD);
+					DrawPercentage(StageLevel.Hard);
+					DrawGraph(StageLevel.Hard);
 					break;
-				case 3:
-					nowLevel = 3;
+				case StageLevel.VeryHard:
 					level.GetComponent<Text>().text = "VeryHard";
-					DrawPercentage(StageNum.VERY_HARD, StageStartId.VERY_HARD);
-					DrawGraph(StageNum.VERY_HARD, StageStartId.VERY_HARD);
+					DrawPercentage(StageLevel.VeryHard);
+					DrawGraph(StageLevel.VeryHard);
 					break;
 				default:
 					throw new NotImplementedException();
@@ -83,8 +82,11 @@ namespace Project.Scripts.RecordScene
 		}
 
 		/* 難易度に合わせた成功割合を描画する */
-		private void DrawPercentage(int stageNum, int stageStartId)
+		private void DrawPercentage(StageLevel stageLevel)
 		{
+			var stageNum = StageInfo.Num[stageLevel];
+			var stageStartId = StageInfo.StageStartId[stageLevel];
+
 			var successStageNum = 0;
 
 			for (var stageId = stageStartId; stageId < stageStartId + stageNum; stageId++)
@@ -103,8 +105,11 @@ namespace Project.Scripts.RecordScene
 		}
 
 		/* 難易度に合わせた棒グラフを描画する */
-		private void DrawGraph(int stageNum, int stageStartId)
+		private void DrawGraph(StageLevel stageLevel)
 		{
+			var stageNum = StageInfo.Num[stageLevel];
+			var stageStartId = StageInfo.StageStartId[stageLevel];
+
 			// 描画するパネル
 			var graphAreaContent = graphArea.GetComponent<RectTransform>();
 
@@ -233,9 +238,9 @@ namespace Project.Scripts.RecordScene
 		/* 左ボタンクリック時の処理 */
 		private void LeftButtonDown()
 		{
-			if (nowLevel == 0)
+			if (nowLevel == StageLevel.Easy)
 			{
-				Draw(3);
+				Draw(StageLevel.VeryHard);
 			}
 			else
 			{
@@ -246,9 +251,9 @@ namespace Project.Scripts.RecordScene
 		/* 右ボタンクリック時の処理 */
 		private void RightButtonDown()
 		{
-			if (nowLevel == 3)
+			if (nowLevel == StageLevel.VeryHard)
 			{
-				Draw(0);
+				Draw(StageLevel.Easy);
 			}
 			else
 			{

--- a/Assets/Project/Scripts/RecordScene/RecordDirector.cs
+++ b/Assets/Project/Scripts/RecordScene/RecordDirector.cs
@@ -40,7 +40,7 @@ namespace Project.Scripts.RecordScene
 			leftButton.GetComponent<Button>().onClick.AddListener(LeftButtonDown);
 			rightButton.GetComponent<Button>().onClick.AddListener(RightButtonDown);
 
-			// "Easy"を表示
+			// 最初は "Easy" を表示
 			Draw(0);
 		}
 
@@ -88,7 +88,7 @@ namespace Project.Scripts.RecordScene
 		/* 難易度に合わせた成功割合を描画する */
 		private void DrawPercentage(int stageNum, int stageStartId)
 		{
-			var clearStageNum = 0;
+			var successStageNum = 0;
 
 			for (var stageId = stageStartId; stageId < stageStartId + stageNum ; stageId++)
 			{
@@ -96,11 +96,11 @@ namespace Project.Scripts.RecordScene
 
 				if (stageStatus.passed)
 				{
-					clearStageNum++;
+					successStageNum++;
 				}
 			}
 
-			var percentageNum = (clearStageNum / (float) stageNum) * 100;
+			var percentageNum = (successStageNum / (float) stageNum) * 100;
 
 			percentage.GetComponent<Text>().text = percentageNum + "%";
 		}
@@ -108,17 +108,6 @@ namespace Project.Scripts.RecordScene
 		/* 難易度に合わせた棒グラフを描画する */
 		private void DrawGraph(int stageNum, int stageStartId)
 		{
-			// 描画する範囲
-			var graphAreaContent = graphArea.GetComponent<RectTransform>();;
-			// 隙間の大きさ
-			var blank = 0.85f / ((1 + RATIO_GRAPH_SPACE) * stageNum + 1);
-			// グラフの横幅
-			var graphWidth = blank * RATIO_GRAPH_SPACE;
-			// グラフ描画の左端
-			var leftPosition = 0.1f;
-			// ステージ番号
-			var stageName = 1;
-
 			// 挑戦回数の最大値を求める
 			var maxChallengeNum = 0;
 			for (var stageId = stageStartId; stageId < stageStartId + stageNum ; stageId++)
@@ -140,27 +129,61 @@ namespace Project.Scripts.RecordScene
 				GameObject.Find("Scale4-Value").GetComponent<Text>().text = maxScale.ToString();
 			}
 
+			// 描画する範囲
+			var graphAreaContent = graphArea.GetComponent<RectTransform>();;
+			// 隙間の大きさ
+			var blankWidth = 0.85f / ((1 + RATIO_GRAPH_SPACE) * stageNum + 1);
+			// グラフの横幅
+			var graphWidth = blankWidth * RATIO_GRAPH_SPACE;
+			// グラフ描画の左端
+			var leftPosition = 0.1f;
+			// グラフ描画の左端
+			var rightPosition = 0.85f;
+			// グラフ本体の上端
+			const float topGraphPosition = 0.9f;
+			// グラフ本体の下端
+			const float bottomGraphPosition = 0.15f;
+			// ステージ番号の下端
+			const float bottomStageNumPosition = 0.05f;
+			// ステージ番号
+			var stageName = 1;
+
 			for (var stageId = stageStartId; stageId < stageStartId + stageNum ; stageId++)
 			{
-				leftPosition += blank;
+				var stageStatus = StageStatus.Get(stageId);
 
+				leftPosition += blankWidth;
+
+				/* ステージ番号の配置 */
+				var stageNumUi = Instantiate(stageNumPrefab);
+				stageNumUi.transform.SetParent(graphAreaContent, false);
+				stageNumUi.GetComponent<Text>().text = stageName.ToString();
+				stageNumUi.GetComponent<RectTransform>().anchorMin = new Vector2(leftPosition, bottomStageNumPosition);
+				stageNumUi.GetComponent<RectTransform>().anchorMax = new Vector2(leftPosition + graphWidth, bottomGraphPosition);
+
+				/* グラフ本体の配置 */
 				var graphUi = Instantiate(graphPrefab);
 				graphUi.transform.SetParent(graphAreaContent, false);
-				graphUi.GetComponent<RectTransform>().anchorMin = new Vector2(leftPosition, 0.15f);
 
-				var stageStatus = StageStatus.Get(stageId);
-				var maxY = 0.15f;
+				// 挑戦回数に応じたグラフの高さ
+				var maxY = bottomGraphPosition;
+
 				if(maxChallengeNum != 0)
 				{
-					maxY = 0.75f * stageStatus.challengeNum / maxScale + 0.15f;
+					// 挑戦回数に関して，グラフ本体の描画範囲に正規化する
+					maxY = (topGraphPosition - bottomGraphPosition) * stageStatus.challengeNum / maxScale + bottomGraphPosition;
 				}
+
+				graphUi.GetComponent<RectTransform>().anchorMin = new Vector2(leftPosition, bottomGraphPosition);
 				graphUi.GetComponent<RectTransform>().anchorMax = new Vector2(leftPosition + graphWidth, maxY);
 
 				if (stageStatus.passed)
 				{
+					/* 成功している場合は，色を水色にして，成功した際の挑戦回数を表示する */
 					graphUi.GetComponent<Image>().color = Color.cyan;
-					var successY = 0.75f * stageStatus.firstSuccessNum / maxScale + 0.15f;
+
 					var successLineUi = Instantiate(successLinePrefab);
+					var successY = (topGraphPosition - bottomGraphPosition) * stageStatus.firstSuccessNum / maxScale + bottomGraphPosition;
 					successLineUi.transform.SetParent(graphAreaContent, false);
 					successLineUi.GetComponent<RectTransform>().anchorMin = new Vector2(leftPosition, successY);
 					successLineUi.GetComponent<RectTransform>().anchorMax = new Vector2(leftPosition + graphWidth, successY);
@@ -170,13 +193,8 @@ namespace Project.Scripts.RecordScene
 					graphUi.GetComponent<Image>().color = Color.red;
 				}
 
-				var stageNumUi = Instantiate(stageNumPrefab);
-				stageNumUi.transform.SetParent(graphAreaContent, false);
-				stageNumUi.GetComponent<Text>().text = stageName.ToString();
-				stageNumUi.GetComponent<RectTransform>().anchorMin = new Vector2(leftPosition, 0.05f);
-				stageNumUi.GetComponent<RectTransform>().anchorMax = new Vector2(leftPosition + graphWidth, 0.15f);
+				leftPosition += graphWidth;
 
-				leftPosition += blank;
 				stageName++;
 			}
 		}

--- a/Assets/Project/Scripts/RecordScene/RecordDirector.cs
+++ b/Assets/Project/Scripts/RecordScene/RecordDirector.cs
@@ -106,7 +106,7 @@ namespace Project.Scripts.RecordScene
 		private void DrawGraph(int stageNum, int stageStartId)
 		{
 			// 描画する範囲
-			var graphAreaContent = GameObject.Find("GraphArea").GetComponent<RectTransform>();;
+			var graphAreaContent = graphArea.GetComponent<RectTransform>();;
 			// 隙間の大きさ
 			var blank = 0.85f / (2 * stageNum + 1);
 			// グラフ描画の左端

--- a/Assets/Project/Scripts/RecordScene/RecordDirector.cs
+++ b/Assets/Project/Scripts/RecordScene/RecordDirector.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using Project.Scripts.Utils.Definitions;
+using Project.Scripts.Utils.PlayerPrefsUtils;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -43,28 +45,52 @@ namespace Project.Scripts.RecordScene
 					level.GetComponent<Text>().text = "Easy";
 					leftButton.SetActive(false);
 					rightButton.SetActive(true);
+					DrawPercentage(StageNum.EASY, StageStartId.EASY);
 					break;
 				case 1:
 					nowLevel = 1;
 					level.GetComponent<Text>().text = "Normal";
 					leftButton.SetActive(true);
 					rightButton.SetActive(true);
+					DrawPercentage(StageNum.NORMAL, StageStartId.NORMAL);
 					break;
 				case 2:
 					nowLevel = 2;
 					level.GetComponent<Text>().text = "Hard";
 					leftButton.SetActive(true);
 					rightButton.SetActive(true);
+					DrawPercentage(StageNum.HARD, StageStartId.HARD);
 					break;
 				case 3:
 					nowLevel = 3;
 					level.GetComponent<Text>().text = "VeryHard";
 					leftButton.SetActive(true);
 					rightButton.SetActive(false);
+					DrawPercentage(StageNum.VERY_HARD, StageStartId.VERY_HARD);
 					break;
 				default:
 					throw new NotImplementedException();
 			}
+		}
+
+		/* 難易度に合わせた成功割合を描画する */
+		private void DrawPercentage(int stageNum, int stageStartId)
+		{
+			var clearStageNum = 0;
+
+			for (var stageId = stageStartId; stageId < stageStartId + stageNum ; stageId++)
+			{
+				var stageStatus = StageStatus.Get(stageId);
+
+				if (stageStatus.passed)
+				{
+					clearStageNum++;
+				}
+			}
+
+			var percentageNum = (clearStageNum / (float) stageNum) * 100;
+
+			percentage.GetComponent<Text>().text = percentageNum + "%";
 		}
 
 		/* 左ボタンクリック時の処理 */

--- a/Assets/Project/Scripts/RecordScene/RecordDirector.cs
+++ b/Assets/Project/Scripts/RecordScene/RecordDirector.cs
@@ -48,21 +48,25 @@ namespace Project.Scripts.RecordScene
 					nowLevel = 0;
 					level.GetComponent<Text>().text = "Easy";
 					DrawPercentage(StageNum.EASY, StageStartId.EASY);
+					DrawGraph(StageNum.EASY, StageStartId.EASY);
 					break;
 				case 1:
 					nowLevel = 1;
 					level.GetComponent<Text>().text = "Normal";
 					DrawPercentage(StageNum.NORMAL, StageStartId.NORMAL);
+					DrawGraph(StageNum.NORMAL, StageStartId.NORMAL);
 					break;
 				case 2:
 					nowLevel = 2;
 					level.GetComponent<Text>().text = "Hard";
 					DrawPercentage(StageNum.HARD, StageStartId.HARD);
+					DrawGraph(StageNum.HARD, StageStartId.HARD);
 					break;
 				case 3:
 					nowLevel = 3;
 					level.GetComponent<Text>().text = "VeryHard";
 					DrawPercentage(StageNum.VERY_HARD, StageStartId.VERY_HARD);
+					DrawGraph(StageNum.VERY_HARD, StageStartId.VERY_HARD);
 					break;
 				default:
 					throw new NotImplementedException();
@@ -87,6 +91,56 @@ namespace Project.Scripts.RecordScene
 			var percentageNum = (clearStageNum / (float) stageNum) * 100;
 
 			percentage.GetComponent<Text>().text = percentageNum + "%";
+		}
+
+		/* 難易度に合わせた棒グラフを描画する */
+		private void DrawGraph(int stageNum, int stageStartId)
+		{
+			// 描画する範囲
+			var graphAreaContent = GameObject.Find("GraphArea").GetComponent<RectTransform>();;
+			// 隙間の大きさ
+			var blank = 0.85f / (2 * stageNum + 1);
+			// グラフ描画の左端
+			var leftPosition = 0.1f;
+			// ステージ番号
+			var stageName = 1;
+
+			// 挑戦回数の最大値を求める
+			var maxChallengeNum = 0;
+			for (var stageId = stageStartId; stageId < stageStartId + stageNum ; stageId++)
+			{
+				var stageStatus = StageStatus.Get(stageId);
+				if (stageStatus.challengeNum > maxChallengeNum)
+				{
+					maxChallengeNum = stageStatus.challengeNum;
+				}
+			}
+
+			for (var stageId = stageStartId; stageId < stageStartId + stageNum ; stageId++)
+			{
+				leftPosition += blank;
+
+				var graphUi = Instantiate(graphPrefab);
+				graphUi.transform.SetParent(graphAreaContent, false);
+				graphUi.GetComponent<RectTransform>().anchorMin = new Vector2(leftPosition, 0.15f);
+
+				var stageStatus = StageStatus.Get(stageId);
+				var maxY = 0.15f;
+				if(maxChallengeNum != 0)
+				{
+					maxY = 0.75f * stageStatus.challengeNum / maxChallengeNum + 0.15f;
+				}
+				graphUi.GetComponent<RectTransform>().anchorMax = new Vector2(leftPosition + blank, maxY);
+
+				var stageNumUi = Instantiate(stageNumPrefab);
+				stageNumUi.transform.SetParent(graphAreaContent, false);
+				stageNumUi.GetComponent<Text>().text = stageName.ToString();
+				stageNumUi.GetComponent<RectTransform>().anchorMin = new Vector2(leftPosition, 0.05f);
+				stageNumUi.GetComponent<RectTransform>().anchorMax = new Vector2(leftPosition + blank, 0.15f);
+
+				leftPosition += blank;
+				stageName++;
+			}
 		}
 
 		/* 左ボタンクリック時の処理 */

--- a/Assets/Project/Scripts/RecordScene/RecordDirector.cs
+++ b/Assets/Project/Scripts/RecordScene/RecordDirector.cs
@@ -1,16 +1,82 @@
-﻿using System.Collections;
-using System.Collections.Generic;
+﻿using System;
 using UnityEngine;
+using UnityEngine.UI;
 
-public class RecordDirector : MonoBehaviour {
+namespace Project.Scripts.RecordScene
+{
+	public class RecordDirector : MonoBehaviour
+	{
+		private GameObject level;
 
-	// Use this for initialization
-	void Start () {
-		
-	}
-	
-	// Update is called once per frame
-	void Update () {
-		
+		private GameObject percentage;
+
+		private GameObject graphArea;
+
+		private GameObject leftButton;
+
+		private GameObject rightButton;
+
+		private int nowLevel;
+
+		private void Awake()
+		{
+			level = GameObject.Find("Level");
+			percentage = GameObject.Find("Percentage");
+			graphArea = GameObject.Find("GraphArea");
+			leftButton = GameObject.Find("LeftButton");
+			rightButton = GameObject.Find("RightButton");
+
+			leftButton.GetComponent<Button>().onClick.AddListener(LeftButtonDown);
+			rightButton.GetComponent<Button>().onClick.AddListener(RightButtonDown);
+
+			// "Easy"を表示
+			Draw(0);
+		}
+
+		/* 難易度に合わせた画面を描画する */
+		private void Draw(int levelNum)
+		{
+			switch (levelNum)
+			{
+				case 0:
+					nowLevel = 0;
+					level.GetComponent<Text>().text = "Easy";
+					leftButton.SetActive(false);
+					rightButton.SetActive(true);
+					break;
+				case 1:
+					nowLevel = 1;
+					level.GetComponent<Text>().text = "Normal";
+					leftButton.SetActive(true);
+					rightButton.SetActive(true);
+					break;
+				case 2:
+					nowLevel = 2;
+					level.GetComponent<Text>().text = "Hard";
+					leftButton.SetActive(true);
+					rightButton.SetActive(true);
+					break;
+				case 3:
+					nowLevel = 3;
+					level.GetComponent<Text>().text = "VeryHard";
+					leftButton.SetActive(true);
+					rightButton.SetActive(false);
+					break;
+				default:
+					throw new NotImplementedException();
+			}
+		}
+
+		/* 左ボタンクリック時の処理 */
+		private void LeftButtonDown()
+		{
+			Draw(nowLevel - 1);
+		}
+
+		/* 右ボタンクリック時の処理 */
+		private void RightButtonDown()
+		{
+			Draw(nowLevel + 1);
+		}
 	}
 }

--- a/Assets/Project/Scripts/RecordScene/RecordDirector.cs
+++ b/Assets/Project/Scripts/RecordScene/RecordDirector.cs
@@ -143,7 +143,7 @@ namespace Project.Scripts.RecordScene
 			var maxChallengeNum = GetMaxChallengeNum(stageNum, stageStartId);
 
 			// 目盛の最大値を求める
-			var maxScale = (float) Math.Ceiling((float) maxChallengeNum / 3) * 3;
+			var maxScale = (float) Math.Ceiling((float) maxChallengeNum / 30) * 30;
 
 			// 目盛を書き換える
 			if (maxScale > 0)

--- a/Assets/Project/Scripts/RecordScene/RecordDirector.cs
+++ b/Assets/Project/Scripts/RecordScene/RecordDirector.cs
@@ -8,6 +8,10 @@ namespace Project.Scripts.RecordScene
 {
 	public class RecordDirector : MonoBehaviour
 	{
+		public GameObject graphPrefab;
+
+		public GameObject stageNumPrefab;
+
 		private GameObject level;
 
 		private GameObject percentage;

--- a/Assets/Project/Scripts/RecordScene/RecordDirector.cs
+++ b/Assets/Project/Scripts/RecordScene/RecordDirector.cs
@@ -43,29 +43,21 @@ namespace Project.Scripts.RecordScene
 				case 0:
 					nowLevel = 0;
 					level.GetComponent<Text>().text = "Easy";
-					leftButton.SetActive(false);
-					rightButton.SetActive(true);
 					DrawPercentage(StageNum.EASY, StageStartId.EASY);
 					break;
 				case 1:
 					nowLevel = 1;
 					level.GetComponent<Text>().text = "Normal";
-					leftButton.SetActive(true);
-					rightButton.SetActive(true);
 					DrawPercentage(StageNum.NORMAL, StageStartId.NORMAL);
 					break;
 				case 2:
 					nowLevel = 2;
 					level.GetComponent<Text>().text = "Hard";
-					leftButton.SetActive(true);
-					rightButton.SetActive(true);
 					DrawPercentage(StageNum.HARD, StageStartId.HARD);
 					break;
 				case 3:
 					nowLevel = 3;
 					level.GetComponent<Text>().text = "VeryHard";
-					leftButton.SetActive(true);
-					rightButton.SetActive(false);
 					DrawPercentage(StageNum.VERY_HARD, StageStartId.VERY_HARD);
 					break;
 				default:
@@ -96,13 +88,27 @@ namespace Project.Scripts.RecordScene
 		/* 左ボタンクリック時の処理 */
 		private void LeftButtonDown()
 		{
-			Draw(nowLevel - 1);
+			if (nowLevel == 0)
+			{
+				Draw(3);
+			}
+			else
+			{
+				Draw(nowLevel - 1);
+			}
 		}
 
 		/* 右ボタンクリック時の処理 */
 		private void RightButtonDown()
 		{
-			Draw(nowLevel + 1);
+			if (nowLevel == 3)
+			{
+				Draw(0);
+			}
+			else
+			{
+				Draw(nowLevel + 1);
+			}
 		}
 	}
 }

--- a/Assets/Project/Scripts/RecordScene/RecordDirector.cs
+++ b/Assets/Project/Scripts/RecordScene/RecordDirector.cs
@@ -139,7 +139,6 @@ namespace Project.Scripts.RecordScene
 			// 棒グラフの横幅
 			var graphWidth = blankWidth * graphWidthRatio;
 
-
 			// 挑戦回数の最大値を求める
 			var maxChallengeNum = GetMaxChallengeNum(stageNum, stageStartId);
 

--- a/Assets/Project/Scripts/RecordScene/RecordDirector.cs
+++ b/Assets/Project/Scripts/RecordScene/RecordDirector.cs
@@ -26,6 +26,9 @@ namespace Project.Scripts.RecordScene
 
 		private int nowLevel;
 
+		// グラフの横幅が隙間の何倍か
+		private const float RATIO_GRAPH_SPACE = 1.0f;
+
 		private void Awake()
 		{
 			level = GameObject.Find("Level");
@@ -108,7 +111,9 @@ namespace Project.Scripts.RecordScene
 			// 描画する範囲
 			var graphAreaContent = graphArea.GetComponent<RectTransform>();;
 			// 隙間の大きさ
-			var blank = 0.85f / (2 * stageNum + 1);
+			var blank = 0.85f / ((1 + RATIO_GRAPH_SPACE) * stageNum + 1);
+			// グラフの横幅
+			var graphWidth = blank * RATIO_GRAPH_SPACE;
 			// グラフ描画の左端
 			var leftPosition = 0.1f;
 			// ステージ番号
@@ -119,6 +124,7 @@ namespace Project.Scripts.RecordScene
 			for (var stageId = stageStartId; stageId < stageStartId + stageNum ; stageId++)
 			{
 				var stageStatus = StageStatus.Get(stageId);
+
 				if (stageStatus.challengeNum > maxChallengeNum)
 				{
 					maxChallengeNum = stageStatus.challengeNum;
@@ -148,7 +154,7 @@ namespace Project.Scripts.RecordScene
 				{
 					maxY = 0.75f * stageStatus.challengeNum / maxScale + 0.15f;
 				}
-				graphUi.GetComponent<RectTransform>().anchorMax = new Vector2(leftPosition + blank, maxY);
+				graphUi.GetComponent<RectTransform>().anchorMax = new Vector2(leftPosition + graphWidth, maxY);
 
 				if (stageStatus.passed)
 				{
@@ -157,7 +163,7 @@ namespace Project.Scripts.RecordScene
 					var successLineUi = Instantiate(successLinePrefab);
 					successLineUi.transform.SetParent(graphAreaContent, false);
 					successLineUi.GetComponent<RectTransform>().anchorMin = new Vector2(leftPosition, successY);
-					successLineUi.GetComponent<RectTransform>().anchorMax = new Vector2(leftPosition + blank, successY);
+					successLineUi.GetComponent<RectTransform>().anchorMax = new Vector2(leftPosition + graphWidth, successY);
 				}
 				else
 				{
@@ -168,7 +174,7 @@ namespace Project.Scripts.RecordScene
 				stageNumUi.transform.SetParent(graphAreaContent, false);
 				stageNumUi.GetComponent<Text>().text = stageName.ToString();
 				stageNumUi.GetComponent<RectTransform>().anchorMin = new Vector2(leftPosition, 0.05f);
-				stageNumUi.GetComponent<RectTransform>().anchorMax = new Vector2(leftPosition + blank, 0.15f);
+				stageNumUi.GetComponent<RectTransform>().anchorMax = new Vector2(leftPosition + graphWidth, 0.15f);
 
 				leftPosition += blank;
 				stageName++;

--- a/Assets/Project/Scripts/RecordScene/RecordDirector.cs
+++ b/Assets/Project/Scripts/RecordScene/RecordDirector.cs
@@ -38,7 +38,7 @@ namespace Project.Scripts.RecordScene
 			rightButton.GetComponent<Button>().onClick.AddListener(RightButtonDown);
 
 			// 最初は "Easy" を表示
-			Draw(0);
+			Draw(StageLevel.Easy);
 		}
 
 		/* 難易度に合わせた画面を描画する */
@@ -54,27 +54,23 @@ namespace Project.Scripts.RecordScene
 			// 難易度の更新
 			nowLevel = stageLevel;
 
+			DrawPercentage(nowLevel);
+
+			DrawGraph(nowLevel);
+
 			switch (nowLevel)
 			{
 				case StageLevel.Easy:
 					levelText.GetComponent<Text>().text = "Easy";
-					DrawPercentage(StageLevel.Easy);
-					DrawGraph(StageLevel.Easy);
 					break;
 				case StageLevel.Normal:
 					levelText.GetComponent<Text>().text = "Normal";
-					DrawPercentage(StageLevel.Normal);
-					DrawGraph(StageLevel.Normal);
 					break;
 				case StageLevel.Hard:
 					levelText.GetComponent<Text>().text = "Hard";
-					DrawPercentage(StageLevel.Hard);
-					DrawGraph(StageLevel.Hard);
 					break;
 				case StageLevel.VeryHard:
 					levelText.GetComponent<Text>().text = "VeryHard";
-					DrawPercentage(StageLevel.VeryHard);
-					DrawGraph(StageLevel.VeryHard);
 					break;
 				default:
 					throw new NotImplementedException();

--- a/Assets/Project/Scripts/RecordScene/RecordDirector.cs
+++ b/Assets/Project/Scripts/RecordScene/RecordDirector.cs
@@ -123,6 +123,12 @@ namespace Project.Scripts.RecordScene
 				}
 			}
 
+			// 目盛の数値を書き換える
+			var maxScale = (float) Math.Ceiling(maxChallengeNum / 3.0f) * 3.0f;
+			GameObject.Find("Scale2-Value").GetComponent<Text>().text = (maxScale / 3).ToString();
+			GameObject.Find("Scale3-Value").GetComponent<Text>().text = (maxScale * 2 / 3).ToString();
+			GameObject.Find("Scale4-Value").GetComponent<Text>().text = maxScale.ToString();
+
 			for (var stageId = stageStartId; stageId < stageStartId + stageNum ; stageId++)
 			{
 				leftPosition += blank;
@@ -135,7 +141,7 @@ namespace Project.Scripts.RecordScene
 				var maxY = 0.15f;
 				if(maxChallengeNum != 0)
 				{
-					maxY = 0.75f * stageStatus.challengeNum / maxChallengeNum + 0.15f;
+					maxY = 0.75f * stageStatus.challengeNum / maxScale + 0.15f;
 				}
 				graphUi.GetComponent<RectTransform>().anchorMax = new Vector2(leftPosition + blank, maxY);
 

--- a/Assets/Project/Scripts/RecordScene/RecordDirector.cs
+++ b/Assets/Project/Scripts/RecordScene/RecordDirector.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class RecordDirector : MonoBehaviour {
+
+	// Use this for initialization
+	void Start () {
+		
+	}
+	
+	// Update is called once per frame
+	void Update () {
+		
+	}
+}

--- a/Assets/Project/Scripts/RecordScene/RecordDirector.cs.meta
+++ b/Assets/Project/Scripts/RecordScene/RecordDirector.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d4b53763965784e018406592f8845568
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/Scripts/StageSelectScene/EasyStageSelectDirector.cs
+++ b/Assets/Project/Scripts/StageSelectScene/EasyStageSelectDirector.cs
@@ -9,10 +9,10 @@ namespace Project.Scripts.StageSelectScene
 		protected override void MakeButtons()
 		{
 			var content = GameObject.Find("Canvas/Scroll View/Viewport/Content/Buttons").GetComponent<RectTransform>();
-			for (var i = 0; i < StageNum.EASY; i++)
+			for (var i = 0; i < StageInfo.Num[StageLevel.Easy]; i++)
 			{
 				// ステージを一意に定めるID
-				var stageId = StageStartId.EASY + i;
+				var stageId = StageInfo.StageStartId[StageLevel.Easy] + i;
 				// ボタンインスタンスを生成
 				var button = Instantiate(stageButtonPrefab);
 				// 名前

--- a/Assets/Project/Scripts/StageSelectScene/HardStageSelectDirector.cs
+++ b/Assets/Project/Scripts/StageSelectScene/HardStageSelectDirector.cs
@@ -9,10 +9,10 @@ namespace Project.Scripts.StageSelectScene
 		protected override void MakeButtons()
 		{
 			var content = GameObject.Find("Canvas/Scroll View/Viewport/Content/Buttons").GetComponent<RectTransform>();
-			for (var i = 0; i < StageNum.HARD; i++)
+			for (var i = 0; i < StageInfo.Num[StageLevel.Hard]; i++)
 			{
 				// ステージを一意に定めるID
-				var stageId = StageStartId.HARD + i;
+				var stageId = StageInfo.StageStartId[StageLevel.Hard] + i;
 				// ボタンインスタンスを生成
 				var button = Instantiate(stageButtonPrefab);
 				// 名前

--- a/Assets/Project/Scripts/StageSelectScene/NormalStageSelectDirector.cs
+++ b/Assets/Project/Scripts/StageSelectScene/NormalStageSelectDirector.cs
@@ -1,5 +1,5 @@
 ﻿using UnityEngine;
-﻿using Project.Scripts.Utils.Definitions;
+using Project.Scripts.Utils.Definitions;
 using UnityEngine.UI;
 
 namespace Project.Scripts.StageSelectScene

--- a/Assets/Project/Scripts/StageSelectScene/NormalStageSelectDirector.cs
+++ b/Assets/Project/Scripts/StageSelectScene/NormalStageSelectDirector.cs
@@ -9,10 +9,10 @@ namespace Project.Scripts.StageSelectScene
 		protected override void MakeButtons()
 		{
 			var content = GameObject.Find("Canvas/Scroll View/Viewport/Content/Buttons").GetComponent<RectTransform>();
-			for (var i = 0; i < StageNum.NORMAL; i++)
+			for (var i = 0; i < StageInfo.Num[StageLevel.Normal]; i++)
 			{
 				// ステージを一意に定めるID
-				var stageId = StageStartId.NORMAL + i;
+				var stageId = StageInfo.StageStartId[StageLevel.Normal] + i;
 				// ボタンインスタンスを生成
 				var button = Instantiate(stageButtonPrefab);
 				// 名前

--- a/Assets/Project/Scripts/StageSelectScene/VeryHardStageSelectDirector.cs
+++ b/Assets/Project/Scripts/StageSelectScene/VeryHardStageSelectDirector.cs
@@ -9,10 +9,10 @@ namespace Project.Scripts.StageSelectScene
 		protected override void MakeButtons()
 		{
 			var content = GameObject.Find("Canvas/Scroll View/Viewport/Content/Buttons").GetComponent<RectTransform>();
-			for (var i = 0; i < StageNum.VERY_HARD; i++)
+			for (var i = 0; i < StageInfo.Num[StageLevel.VeryHard]; i++)
 			{
 				// ステージを一意に定めるID
-				var stageId = StageStartId.VERY_HARD + i;
+				var stageId = StageInfo.StageStartId[StageLevel.VeryHard] + i;
 				// ボタンインスタンスを生成
 				var button = Instantiate(stageButtonPrefab);
 				// 名前

--- a/Assets/Project/Scripts/Utils/Definitions/StageDefinitions.cs
+++ b/Assets/Project/Scripts/Utils/Definitions/StageDefinitions.cs
@@ -1,19 +1,32 @@
-﻿namespace Project.Scripts.Utils.Definitions
+﻿using System.Collections.Generic;
+
+namespace Project.Scripts.Utils.Definitions
 {
-	public static class StageNum
+	public enum StageLevel
 	{
-		public const int EASY = 10;
-		public const int NORMAL = 10;
-		public const int HARD = 10;
-		public const int VERY_HARD = 10;
+		Easy = 0,
+		Normal,
+		Hard,
+		VeryHard
 	}
 
-	public static class StageStartId
+	public static class StageInfo
 	{
-		public const int EASY = 1;
-		public const int NORMAL = 1001;
-		public const int HARD = 2001;
-		public const int VERY_HARD = 3001;
+		public static readonly Dictionary<StageLevel, int> Num = new Dictionary<StageLevel, int>()
+		{
+			{StageLevel.Easy, 10},
+			{StageLevel.Normal, 10},
+			{StageLevel.Hard, 10},
+			{StageLevel.VeryHard, 10}
+		};
+
+		public static readonly Dictionary<StageLevel, int> StageStartId = new Dictionary<StageLevel, int>()
+		{
+			{StageLevel.Easy, 1},
+			{StageLevel.Normal, 1001},
+			{StageLevel.Hard, 2001},
+			{StageLevel.VeryHard, 3001}
+		};
 	}
 
 	public static class StageSize

--- a/Assets/Project/Scripts/Utils/Definitions/StringDefinitions.cs
+++ b/Assets/Project/Scripts/Utils/Definitions/StringDefinitions.cs
@@ -29,5 +29,6 @@
 		public const string NUMBER_PANEL = "NumberPanel";
 		public const string BULLET = "Bullet";
 		public const string BULLET_WARNING = "BulletWarning";
+		public const string GRAPH_UI = "GraphUi";
 	}
 }

--- a/Assets/Project/Scripts/Utils/PlayerPrefsUtils/StageStatus.cs
+++ b/Assets/Project/Scripts/Utils/PlayerPrefsUtils/StageStatus.cs
@@ -38,8 +38,8 @@ namespace Project.Scripts.Utils.PlayerPrefsUtils
 
 		public void ClearStage(int stageId)
 		{
+			if (!passed) firstSuccessNum = challengeNum;
 			passed = true;
-			firstSuccessNum = challengeNum;
 			Set(stageId, this);
 		}
 

--- a/Assets/Project/Scripts/Utils/PlayerPrefsUtils/StageStatus.cs
+++ b/Assets/Project/Scripts/Utils/PlayerPrefsUtils/StageStatus.cs
@@ -18,6 +18,9 @@ namespace Project.Scripts.Utils.PlayerPrefsUtils
 		// 失敗回数
 		public int failureNum = 0;
 
+		// 初成功にかかった挑戦回数
+		public int firstSuccessNum = -1;
+
 		private static void Set(int stageId, StageStatus stageStatus)
 		{
 			MyPlayerPrefs.SetObject(PlayerPrefsKeys.STAGE_STATUS_KEY + stageId, stageStatus);
@@ -36,6 +39,7 @@ namespace Project.Scripts.Utils.PlayerPrefsUtils
 		public void ClearStage(int stageId)
 		{
 			passed = true;
+			firstSuccessNum = challengeNum;
 			Set(stageId, this);
 		}
 

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -8,6 +8,7 @@ TagManager:
   - NumberPanel
   - BulletWarning
   - Tile
+  - GraphUi
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
## 対象イシュー
https://app.mmth.pro/projects/18382/tasks#/show/202595
https://app.mmth.pro/projects/18382/tasks#/show/150178
https://app.mmth.pro/projects/18382/tasks#/show/230395

## 概要
記録画面の大まかな画面設計をする．

機能概要は以下の通りである．
- 難易度ごとに記録画面を再描画し，複数画面があるかのような実装
- 表示内容は，"表示難易度変更ボタン"，"難易度"，"成功割合"，"棒グラフ描画エリア"
- 棒グラフ描画エリアにおいて，y軸と目盛は固定．目盛数値とステージ番号，棒グラフ本体は Prefab を用いて，動的に生成
- 記録をリセットする機能を，設定画面に実装

## 技術的な内容
- 画面設計（キャプチャ参照）が中心
- Prefab を使ったより再利用可能な実装

## 今後の課題
- フォントを Best Fit にして崩れないようにする
- グラフの表示をアニメーションにする
- 成功割合の周りにゲージを用意し，アニメーションで表示する

## キャプチャ
設計図は以下の通り．

![色々](https://user-images.githubusercontent.com/26104258/58342816-682fe000-7e8c-11e9-87cd-3b59aa6387b4.png)

![色々 2](https://user-images.githubusercontent.com/26104258/58342846-85fd4500-7e8c-11e9-9d20-aa3dfd4715fe.png)


