### PR TITLE
最終タイルにいる数字パネルは煌く

### DIFF
--- a/Assets/Project/Prefabs/GamePlayScene/Panel/numberPanel1Prefab.prefab
+++ b/Assets/Project/Prefabs/GamePlayScene/Panel/numberPanel1Prefab.prefab
@@ -21,7 +21,7 @@ GameObject:
   - component: {fileID: 4966638403937660}
   - component: {fileID: 212448339726182954}
   - component: {fileID: 114039046923894958}
-  m_Layer: 0
+  m_Layer: 8
   m_Name: numberPanel1Prefab
   m_TagString: NumberPanel
   m_Icon: {fileID: 0}

--- a/Assets/Project/Prefabs/GamePlayScene/Panel/numberPanel2Prefab.prefab
+++ b/Assets/Project/Prefabs/GamePlayScene/Panel/numberPanel2Prefab.prefab
@@ -21,7 +21,7 @@ GameObject:
   - component: {fileID: 4089093857491056}
   - component: {fileID: 212352183532753192}
   - component: {fileID: 114286553841917606}
-  m_Layer: 0
+  m_Layer: 8
   m_Name: numberPanel2Prefab
   m_TagString: NumberPanel
   m_Icon: {fileID: 0}

--- a/Assets/Project/Prefabs/GamePlayScene/Panel/numberPanel3Prefab.prefab
+++ b/Assets/Project/Prefabs/GamePlayScene/Panel/numberPanel3Prefab.prefab
@@ -21,7 +21,7 @@ GameObject:
   - component: {fileID: 4231327648605276}
   - component: {fileID: 212313641232563784}
   - component: {fileID: 114183974097513432}
-  m_Layer: 0
+  m_Layer: 8
   m_Name: numberPanel3Prefab
   m_TagString: NumberPanel
   m_Icon: {fileID: 0}

--- a/Assets/Project/Prefabs/GamePlayScene/Panel/numberPanel4Prefab.prefab
+++ b/Assets/Project/Prefabs/GamePlayScene/Panel/numberPanel4Prefab.prefab
@@ -21,7 +21,7 @@ GameObject:
   - component: {fileID: 4447536029278920}
   - component: {fileID: 212613370315751616}
   - component: {fileID: 114706222321565858}
-  m_Layer: 0
+  m_Layer: 8
   m_Name: numberPanel4Prefab
   m_TagString: NumberPanel
   m_Icon: {fileID: 0}

--- a/Assets/Project/Prefabs/GamePlayScene/Panel/numberPanel5Prefab.prefab
+++ b/Assets/Project/Prefabs/GamePlayScene/Panel/numberPanel5Prefab.prefab
@@ -21,7 +21,7 @@ GameObject:
   - component: {fileID: 4396754789075924}
   - component: {fileID: 212121604812214678}
   - component: {fileID: 114216059395962064}
-  m_Layer: 0
+  m_Layer: 8
   m_Name: numberPanel5Prefab
   m_TagString: NumberPanel
   m_Icon: {fileID: 0}

--- a/Assets/Project/Prefabs/GamePlayScene/Panel/numberPanel6Prefab.prefab
+++ b/Assets/Project/Prefabs/GamePlayScene/Panel/numberPanel6Prefab.prefab
@@ -21,7 +21,7 @@ GameObject:
   - component: {fileID: 4361382853137498}
   - component: {fileID: 212854563969274332}
   - component: {fileID: 114366300261715524}
-  m_Layer: 0
+  m_Layer: 8
   m_Name: numberPanel6Prefab
   m_TagString: NumberPanel
   m_Icon: {fileID: 0}

--- a/Assets/Project/Prefabs/GamePlayScene/Panel/numberPanel7Prefab.prefab
+++ b/Assets/Project/Prefabs/GamePlayScene/Panel/numberPanel7Prefab.prefab
@@ -21,7 +21,7 @@ GameObject:
   - component: {fileID: 4120026944265344}
   - component: {fileID: 212202074505269142}
   - component: {fileID: 114737773389269764}
-  m_Layer: 0
+  m_Layer: 8
   m_Name: numberPanel7Prefab
   m_TagString: NumberPanel
   m_Icon: {fileID: 0}

--- a/Assets/Project/Prefabs/GamePlayScene/Panel/numberPanel8Prefab.prefab
+++ b/Assets/Project/Prefabs/GamePlayScene/Panel/numberPanel8Prefab.prefab
@@ -21,7 +21,7 @@ GameObject:
   - component: {fileID: 4394834783775084}
   - component: {fileID: 212039555176909420}
   - component: {fileID: 114365662992635878}
-  m_Layer: 0
+  m_Layer: 8
   m_Name: numberPanel8Prefab
   m_TagString: NumberPanel
   m_Icon: {fileID: 0}

--- a/Assets/Project/Resources/PostProcessProfile.meta
+++ b/Assets/Project/Resources/PostProcessProfile.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c1ab24b485a104674b35d20ee7d115a9
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/Resources/PostProcessProfile/GamePlayScene.meta
+++ b/Assets/Project/Resources/PostProcessProfile/GamePlayScene.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 534d9315d5ee84d0786b3e52351c3acb
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/Resources/PostProcessProfile/GamePlayScene/numberPanelPrefab.asset
+++ b/Assets/Project/Resources/PostProcessProfile/GamePlayScene/numberPanelPrefab.asset
@@ -9,7 +9,7 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 8e6292b2c06870d4495f009f912b9600, type: 3}
-  m_Name: numberPanelPrefab Profile
+  m_Name: numberPanelPrefab
   m_EditorClassIdentifier: 
   settings:
   - {fileID: 114712526957989830}
@@ -32,7 +32,7 @@ MonoBehaviour:
     overrideState: 1
     value: 1
   threshold:
-    overrideState: 1
+    overrideState: 0
     value: 1
   softKnee:
     overrideState: 0

--- a/Assets/Project/Resources/PostProcessProfile/GamePlayScene/numberPanelPrefab.asset
+++ b/Assets/Project/Resources/PostProcessProfile/GamePlayScene/numberPanelPrefab.asset
@@ -1,0 +1,61 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8e6292b2c06870d4495f009f912b9600, type: 3}
+  m_Name: numberPanelPrefab Profile
+  m_EditorClassIdentifier: 
+  settings:
+  - {fileID: 114712526957989830}
+--- !u!114 &114712526957989830
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 48a79b01ea5641d4aa6daa2e23605641, type: 3}
+  m_Name: Bloom
+  m_EditorClassIdentifier: 
+  active: 1
+  enabled:
+    overrideState: 1
+    value: 1
+  intensity:
+    overrideState: 1
+    value: 1
+  threshold:
+    overrideState: 1
+    value: 1
+  softKnee:
+    overrideState: 0
+    value: 0.5
+  clamp:
+    overrideState: 0
+    value: 65472
+  diffusion:
+    overrideState: 0
+    value: 7
+  anamorphicRatio:
+    overrideState: 0
+    value: 0
+  color:
+    overrideState: 1
+    value: {r: 0, g: 1, b: 1, a: 1}
+  fastMode:
+    overrideState: 0
+    value: 0
+  dirtTexture:
+    overrideState: 0
+    value: {fileID: 0}
+    defaultState: 1
+  dirtIntensity:
+    overrideState: 0
+    value: 0

--- a/Assets/Project/Resources/PostProcessProfile/GamePlayScene/numberPanelPrefab.asset.meta
+++ b/Assets/Project/Resources/PostProcessProfile/GamePlayScene/numberPanelPrefab.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5cab2e1f0f1b042e7ae4f94aa66dfd89
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/Scenes/GamePlayScene.unity
+++ b/Assets/Project/Scenes/GamePlayScene.unity
@@ -281,6 +281,7 @@ GameObject:
   - component: {fileID: 574476887}
   - component: {fileID: 574476886}
   - component: {fileID: 574476885}
+  - component: {fileID: 574476889}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -334,7 +335,7 @@ Camera:
   m_HDR: 1
   m_AllowMSAA: 1
   m_AllowDynamicResolution: 0
-  m_ForceIntoRT: 0
+  m_ForceIntoRT: 1
   m_OcclusionCulling: 1
   m_StereoConvergence: 10
   m_StereoSeparation: 0.022
@@ -351,6 +352,65 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &574476889
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 574476884}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 948f4100a11a5c24981795d21301da5c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  volumeTrigger: {fileID: 574476888}
+  volumeLayer:
+    serializedVersion: 2
+    m_Bits: 256
+  stopNaNPropagation: 1
+  finalBlitToCameraTarget: 1
+  antialiasingMode: 0
+  temporalAntialiasing:
+    jitterSpread: 0.75
+    sharpness: 0.25
+    stationaryBlending: 0.95
+    motionBlending: 0.85
+  subpixelMorphologicalAntialiasing:
+    quality: 2
+  fastApproximateAntialiasing:
+    fastMode: 0
+    keepAlpha: 0
+  fog:
+    enabled: 1
+    excludeSkybox: 1
+  debugLayer:
+    lightMeter:
+      width: 512
+      height: 256
+      showCurves: 1
+    histogram:
+      width: 512
+      height: 256
+      channel: 3
+    waveform:
+      exposure: 0.12
+      height: 256
+    vectorscope:
+      size: 256
+      exposure: 0.12
+    overlaySettings:
+      linearDepth: 0
+      motionColorIntensity: 4
+      motionGridSize: 64
+      colorBlindnessType: 0
+      colorBlindnessStrength: 1
+  m_Resources: {fileID: 11400000, guid: d82512f9c8e5d4a4d938b575d47f88d4, type: 2}
+  m_ShowToolkit: 0
+  m_ShowCustomSorter: 0
+  breakBeforeColorGrading: 0
+  m_BeforeTransparentBundles: []
+  m_BeforeStackBundles: []
+  m_AfterStackBundles: []
 --- !u!1 &719677482
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Project/Scripts/GamePlayScene/Panel/NumberPanelController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Panel/NumberPanelController.cs
@@ -22,11 +22,8 @@ namespace Project.Scripts.GamePlayScene.Panel
 			// 当たり判定と，フリック検知のアタッチ
 			gameObject.AddComponent<BoxCollider2D>();
 			// 光らせるためのコンポーネントをアタッチ
-			gameObject.AddComponent<PostProcessVolume>();
-			var profile = Resources.Load<PostProcessProfile>("PostProcessProfile/GamePlayScene/numberPanelPrefab");
-			GetComponent<PostProcessVolume>().isGlobal = true;
-			GetComponent<PostProcessVolume>().profile = profile;
-			AddSpriteGlow();
+			AddPostProcessVolume();
+			AddSpriteGlowEffect();
 		}
 
 		protected override void Start()
@@ -76,8 +73,17 @@ namespace Project.Scripts.GamePlayScene.Panel
 			gamePlayDirector.Dispatch(GamePlayDirector.GameState.Failure);
 		}
 
+		/* SpriteGlowEffect コンポーネントに必要なコンポーネント */
+		private void AddPostProcessVolume()
+		{
+			gameObject.AddComponent<PostProcessVolume>();
+			GetComponent<PostProcessVolume>().isGlobal = true;
+			var profile = Resources.Load<PostProcessProfile>("PostProcessProfile/GamePlayScene/numberPanelPrefab");
+			GetComponent<PostProcessVolume>().profile = profile;
+		}
+
 		/* オブジェクトを光らせる */
-		private void AddSpriteGlow()
+		private void AddSpriteGlowEffect()
 		{
 			gameObject.AddComponent<SpriteGlowEffect>();
 			GetComponent<SpriteGlowEffect>().GlowColor = new Color32(0, 255, 255, 255);

--- a/Assets/Project/Scripts/GamePlayScene/Panel/NumberPanelController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Panel/NumberPanelController.cs
@@ -63,8 +63,8 @@ namespace Project.Scripts.GamePlayScene.Panel
 			adapted = transform.parent.gameObject == finalTile;
 			// 最終タイルにいるかどうかで，光らせるかを決める
 			GetComponent<SpriteGlowEffect>().enabled = adapted;
-			// 成功判定
-			gamePlayDirector.CheckClear();
+			// adapted が true になっていれば (必要条件) 成功判定をする
+			if (adapted) gamePlayDirector.CheckClear();
 		}
 
 		private void OnTriggerEnter2D(Collider2D other)

--- a/Assets/Project/Scripts/GamePlayScene/Panel/NumberPanelController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Panel/NumberPanelController.cs
@@ -51,6 +51,7 @@ namespace Project.Scripts.GamePlayScene.Panel
 			{
 				return gameObject;
 			}
+
 			return null;
 		}
 
@@ -68,6 +69,7 @@ namespace Project.Scripts.GamePlayScene.Panel
 					Destroy(GetComponent<SpriteGlowEffect>());
 				}
 			}
+
 			// 成功判定
 			gamePlayDirector.CheckClear();
 		}

--- a/Assets/Project/Scripts/GamePlayScene/Panel/NumberPanelController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Panel/NumberPanelController.cs
@@ -1,6 +1,8 @@
 ﻿using Project.Scripts.Utils.Definitions;
 using Project.Scripts.Utils.Library;
+using SpriteGlow;
 using UnityEngine;
+using UnityEngine.Rendering.PostProcessing;
 
 namespace Project.Scripts.GamePlayScene.Panel
 {
@@ -19,6 +21,11 @@ namespace Project.Scripts.GamePlayScene.Panel
 			base.Awake();
 			// 当たり判定と，フリック検知のアタッチ
 			gameObject.AddComponent<BoxCollider2D>();
+			// 光らせるためのコンポーネントをアタッチ
+			gameObject.AddComponent<PostProcessVolume>();
+			var profile = Resources.Load<PostProcessProfile>("PostProcessProfile/GamePlayScene/numberPanelPrefab");
+			GetComponent<PostProcessVolume>().isGlobal = true;
+			GetComponent<PostProcessVolume>().profile = profile;
 		}
 
 		protected override void Start()
@@ -26,6 +33,8 @@ namespace Project.Scripts.GamePlayScene.Panel
 			base.Start();
 			// 初期状態で最終タイルにいるかどうかの状態を変える
 			adapted = transform.parent.gameObject == finalTile;
+			// 最終タイルにいる場合，光らせる
+			if (adapted) AddSpriteGlow();
 		}
 
 		public void Initialize(int panelNum, int initialTileNum, int finalTileNum)
@@ -50,6 +59,15 @@ namespace Project.Scripts.GamePlayScene.Panel
 			base.UpdateTile(targetTile);
 			// 最終タイルにいるかどうかで状態を変える
 			adapted = transform.parent.gameObject == finalTile;
+			// 最終タイルにいるかどうかで，光らせるかを決める
+			if (adapted) AddSpriteGlow();
+			else
+			{
+				if (GetComponent<SpriteGlowEffect>() != null)
+				{
+					Destroy(GetComponent<SpriteGlowEffect>());
+				}
+			}
 			// 成功判定
 			gamePlayDirector.CheckClear();
 		}
@@ -61,6 +79,15 @@ namespace Project.Scripts.GamePlayScene.Panel
 			gameObject.GetComponent<SpriteRenderer>().color = Color.yellow;
 			// 失敗状態に移行する
 			gamePlayDirector.Dispatch(GamePlayDirector.GameState.Failure);
+		}
+
+		/* オブジェクトを光らせる */
+		private void AddSpriteGlow()
+		{
+			gameObject.AddComponent<SpriteGlowEffect>();
+			GetComponent<SpriteGlowEffect>().GlowColor = new Color32(0, 255, 255, 255);
+			GetComponent<SpriteGlowEffect>().GlowBrightness = 3.0f;
+			GetComponent<SpriteGlowEffect>().OutlineWidth = 6;
 		}
 	}
 }

--- a/Assets/Project/Scripts/GamePlayScene/Panel/NumberPanelController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Panel/NumberPanelController.cs
@@ -26,6 +26,7 @@ namespace Project.Scripts.GamePlayScene.Panel
 			var profile = Resources.Load<PostProcessProfile>("PostProcessProfile/GamePlayScene/numberPanelPrefab");
 			GetComponent<PostProcessVolume>().isGlobal = true;
 			GetComponent<PostProcessVolume>().profile = profile;
+			AddSpriteGlow();
 		}
 
 		protected override void Start()
@@ -33,8 +34,8 @@ namespace Project.Scripts.GamePlayScene.Panel
 			base.Start();
 			// 初期状態で最終タイルにいるかどうかの状態を変える
 			adapted = transform.parent.gameObject == finalTile;
-			// 最終タイルにいる場合，光らせる
-			if (adapted) AddSpriteGlow();
+			// 最終タイルにいるかどうかで，光らせるかを決める
+			GetComponent<SpriteGlowEffect>().enabled = adapted;
 		}
 
 		public void Initialize(int panelNum, int initialTileNum, int finalTileNum)
@@ -61,15 +62,7 @@ namespace Project.Scripts.GamePlayScene.Panel
 			// 最終タイルにいるかどうかで状態を変える
 			adapted = transform.parent.gameObject == finalTile;
 			// 最終タイルにいるかどうかで，光らせるかを決める
-			if (adapted) AddSpriteGlow();
-			else
-			{
-				if (GetComponent<SpriteGlowEffect>() != null)
-				{
-					Destroy(GetComponent<SpriteGlowEffect>());
-				}
-			}
-
+			GetComponent<SpriteGlowEffect>().enabled = adapted;
 			// 成功判定
 			gamePlayDirector.CheckClear();
 		}

--- a/Assets/SpriteGlow.meta
+++ b/Assets/SpriteGlow.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: bc24a243bddc57143829a09bb64ff386
+folderAsset: yes
+timeCreated: 1497111257
+licenseType: Pro
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/SpriteGlow/LICENSE.txt
+++ b/Assets/SpriteGlow/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 Artyom Sovetnikov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Assets/SpriteGlow/LICENSE.txt.meta
+++ b/Assets/SpriteGlow/LICENSE.txt.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 56a54694c1a68ca44bdf87d1647bcaa3
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/SpriteGlow/SpriteGlowEffect.cs
+++ b/Assets/SpriteGlow/SpriteGlowEffect.cs
@@ -1,0 +1,111 @@
+﻿using UnityEngine;
+
+namespace SpriteGlow
+{
+    /// <summary>
+    /// Adds an HDR outline over the <see cref="SpriteRenderer"/>'s sprite borders.
+    /// Can be used in conjuction with bloom post-processing to create a glow effect.
+    /// </summary>
+    [AddComponentMenu("Effects/Sprite Glow")]
+    [RequireComponent(typeof(SpriteRenderer)), DisallowMultipleComponent, ExecuteInEditMode]
+    public class SpriteGlowEffect : MonoBehaviour
+    {
+        public SpriteRenderer Renderer { get; private set; }
+        public Color GlowColor
+        {
+            get { return glowColor; }
+            set { if (glowColor != value) { glowColor = value; SetMaterialProperties(); } }
+        }
+        public float GlowBrightness
+        {
+            get { return glowBrightness; }
+            set { if (glowBrightness != value) { glowBrightness = value; SetMaterialProperties(); } }
+        }
+        public int OutlineWidth
+        {
+            get { return outlineWidth; }
+            set { if (outlineWidth != value) { outlineWidth = value; SetMaterialProperties(); } }
+        }
+        public float AlphaThreshold
+        {
+            get { return alphaThreshold; }
+            set { if (alphaThreshold != value) { alphaThreshold = value; SetMaterialProperties(); } }
+        }
+        public bool DrawOutside
+        {
+            get { return drawOutside; }
+            set { if (drawOutside != value) { drawOutside = value; SetMaterialProperties(); } }
+        }
+        public bool EnableInstancing
+        {
+            get { return enableInstancing; }
+            set { if (enableInstancing != value) { enableInstancing = value; SetMaterialProperties(); } }
+        }
+
+        [Tooltip("Base color of the glow.")]
+        [SerializeField] private Color glowColor = Color.white;
+        [Tooltip("The brightness (power) of the glow."), Range(1, 10)]
+        [SerializeField] private float glowBrightness = 2f;
+        [Tooltip("Width of the outline, in texels."), Range(0, 10)]
+        [SerializeField] private int outlineWidth = 1;
+        [Tooltip("Threshold to determine sprite borders."), Range(0f, 1f)]
+        [SerializeField] private float alphaThreshold = .01f;
+        [Tooltip("Whether the outline should only be drawn outside of the sprite borders. Make sure sprite texture has sufficient transparent space for the required outline width.")]
+        [SerializeField] private bool drawOutside = false;
+        [Tooltip("Whether to enable GPU instancing.")]
+        [SerializeField] private bool enableInstancing = false;
+
+        private static readonly int isOutlineEnabledId = Shader.PropertyToID("_IsOutlineEnabled");
+        private static readonly int outlineColorId = Shader.PropertyToID("_OutlineColor");
+        private static readonly int outlineSizeId = Shader.PropertyToID("_OutlineSize");
+        private static readonly int alphaThresholdId = Shader.PropertyToID("_AlphaThreshold");
+
+        private MaterialPropertyBlock materialProperties;
+
+        private void Awake ()
+        {
+            Renderer = GetComponent<SpriteRenderer>();
+        }
+
+        private void OnEnable ()
+        {
+            SetMaterialProperties();
+        }
+
+        private void OnDisable ()
+        {
+            SetMaterialProperties();
+        }
+
+        private void OnValidate ()
+        {
+            if (!isActiveAndEnabled) return;
+
+            // Update material properties when changing serialized fields with editor GUI.
+            SetMaterialProperties();
+        }
+
+        private void OnDidApplyAnimationProperties ()
+        {
+            // Update material properties when changing serialized fields with Unity animation.
+            SetMaterialProperties();
+        }
+
+        private void SetMaterialProperties ()
+        {
+            if (!Renderer) return;
+
+            Renderer.sharedMaterial = SpriteGlowMaterial.GetSharedFor(this);
+
+            if (materialProperties == null) // Initializing it at `Awake` or `OnEnable` causes nullref in editor in some cases.
+                materialProperties = new MaterialPropertyBlock();
+
+            materialProperties.SetFloat(isOutlineEnabledId, isActiveAndEnabled ? 1 : 0);
+            materialProperties.SetColor(outlineColorId, GlowColor * GlowBrightness);
+            materialProperties.SetFloat(outlineSizeId, OutlineWidth);
+            materialProperties.SetFloat(alphaThresholdId, AlphaThreshold);
+
+            Renderer.SetPropertyBlock(materialProperties);
+        }
+    }
+}

--- a/Assets/SpriteGlow/SpriteGlowEffect.cs.meta
+++ b/Assets/SpriteGlow/SpriteGlowEffect.cs.meta
@@ -1,0 +1,14 @@
+fileFormatVersion: 2
+guid: e8f6d3c6e4250e84192f5b34ce9e71bc
+timeCreated: 1497183103
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences:
+  - spriteOutlineMaterial: {fileID: 2100000, guid: 03131355b57b4a24094896e8d133d808,
+      type: 2}
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/SpriteGlow/SpriteGlowMaterial.cs
+++ b/Assets/SpriteGlow/SpriteGlowMaterial.cs
@@ -1,0 +1,45 @@
+﻿using System.Collections.Generic;
+using UnityEngine;
+
+namespace SpriteGlow
+{
+    public class SpriteGlowMaterial : Material
+    {
+        public Texture SpriteTexture { get { return mainTexture; } }
+        public bool DrawOutside { get { return IsKeywordEnabled(outsideMaterialKeyword); } }
+        public bool InstancingEnabled { get { return enableInstancing; } }
+
+        private const string outlineShaderName = "Sprites/Outline";
+        private const string outsideMaterialKeyword = "SPRITE_OUTLINE_OUTSIDE";
+        private static readonly Shader outlineShader = Shader.Find(outlineShaderName);
+
+        private static List<SpriteGlowMaterial> sharedMaterials = new List<SpriteGlowMaterial>();
+
+        public SpriteGlowMaterial (Texture spriteTexture, bool drawOutside = false, bool instancingEnabled = false)
+            : base(outlineShader)
+        {
+            if (!outlineShader) Debug.LogError(string.Format("{0} shader not found. Make sure the shader is included to the build.", outlineShaderName));
+
+            mainTexture = spriteTexture;
+            if (drawOutside) EnableKeyword(outsideMaterialKeyword);
+            if (instancingEnabled) enableInstancing = true;
+        }
+
+        public static Material GetSharedFor (SpriteGlowEffect spriteGlow)
+        {
+            for (int i = 0; i < sharedMaterials.Count; i++)
+            {
+                if (sharedMaterials[i].SpriteTexture == spriteGlow.Renderer.sprite.texture &&
+                    sharedMaterials[i].DrawOutside == spriteGlow.DrawOutside &&
+                    sharedMaterials[i].InstancingEnabled == spriteGlow.EnableInstancing)
+                    return sharedMaterials[i];
+            }
+
+            var material = new SpriteGlowMaterial(spriteGlow.Renderer.sprite.texture, spriteGlow.DrawOutside, spriteGlow.EnableInstancing);
+            material.hideFlags = HideFlags.DontSaveInBuild | HideFlags.DontSaveInEditor | HideFlags.NotEditable;
+            sharedMaterials.Add(material);
+
+            return material;
+        }
+    }
+}

--- a/Assets/SpriteGlow/SpriteGlowMaterial.cs.meta
+++ b/Assets/SpriteGlow/SpriteGlowMaterial.cs.meta
@@ -1,0 +1,14 @@
+fileFormatVersion: 2
+guid: a7af5f0dbc0a2fd48b175d8fd1ae86a4
+timeCreated: 1497183103
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences:
+  - spriteOutlineMaterial: {fileID: 2100000, guid: 03131355b57b4a24094896e8d133d808,
+      type: 2}
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/SpriteGlow/SpriteOutline.shader
+++ b/Assets/SpriteGlow/SpriteOutline.shader
@@ -1,0 +1,241 @@
+﻿// Draws an HDR outline over the sprite borders. 
+// Based on Sprites/Default shader from Unity 2017.3.
+
+Shader "Sprites/Outline"
+{
+    Properties
+    {
+        [PerRendererData] _MainTex("Sprite Texture", 2D) = "white" {}
+        _Color("Tint", Color) = (1,1,1,1)
+        [MaterialToggle] PixelSnap("Pixel snap", Float) = 0
+        [HideInInspector] _RendererColor("RendererColor", Color) = (1,1,1,1)
+        [HideInInspector] _Flip("Flip", Vector) = (1,1,1,1)
+        [PerRendererData] _AlphaTex("External Alpha", 2D) = "white" {}
+        [PerRendererData] _EnableExternalAlpha("Enable External Alpha", Float) = 0
+
+        [MaterialToggle] _IsOutlineEnabled("Enable Outline", float) = 0
+        [HDR] _OutlineColor("Outline Color", Color) = (1,1,1,1)
+        _OutlineSize("Outline Size", Range(1, 10)) = 1
+        _AlphaThreshold("Alpha Threshold", Range(0, 1)) = 0.01
+    }
+
+    SubShader
+    {
+        Tags
+        {
+            "Queue" = "Transparent"
+            "IgnoreProjector" = "True"
+            "RenderType" = "Transparent"
+            "PreviewType" = "Plane"
+            "CanUseSpriteAtlas" = "True"
+        }
+
+        Cull Off
+        Lighting Off
+        ZWrite Off
+        Blend One OneMinusSrcAlpha
+
+        Pass
+        {
+            CGPROGRAM
+
+            #include "UnityCG.cginc"
+
+            #pragma vertex ComputeVertex
+            #pragma fragment ComputeFragment
+            #pragma target 2.0
+            #pragma multi_compile_instancing
+            #pragma multi_compile _ PIXELSNAP_ON
+            #pragma multi_compile _ ETC1_EXTERNAL_ALPHA
+            #pragma multi_compile _ SPRITE_OUTLINE_OUTSIDE
+
+            #ifndef SAMPLE_DEPTH_LIMIT
+            #define SAMPLE_DEPTH_LIMIT 10
+            #endif
+
+            #ifdef UNITY_INSTANCING_ENABLED
+            UNITY_INSTANCING_BUFFER_START(PerDrawSprite)
+            UNITY_DEFINE_INSTANCED_PROP(fixed4, unity_SpriteRendererColorArray)
+            UNITY_DEFINE_INSTANCED_PROP(fixed2, unity_SpriteFlipArray)
+            UNITY_INSTANCING_BUFFER_END(PerDrawSprite)
+            #define _RendererColor UNITY_ACCESS_INSTANCED_PROP(PerDrawSprite, unity_SpriteRendererColorArray)
+            #define _Flip UNITY_ACCESS_INSTANCED_PROP(PerDrawSprite, unity_SpriteFlipArray)
+
+            UNITY_INSTANCING_BUFFER_START(PerDrawSpriteOutline)
+            UNITY_DEFINE_INSTANCED_PROP(float,  _IsOutlineEnabled)
+            UNITY_DEFINE_INSTANCED_PROP(fixed4, _OutlineColor)
+            UNITY_DEFINE_INSTANCED_PROP(float,  _OutlineSize)
+            UNITY_DEFINE_INSTANCED_PROP(float,  _AlphaThreshold)
+            UNITY_INSTANCING_BUFFER_END(PerDrawSpriteOutline)
+            #endif 
+
+            CBUFFER_START(UnityPerDrawSprite)
+            #ifndef UNITY_INSTANCING_ENABLED
+            fixed4 _RendererColor;
+            fixed2 _Flip;
+            #endif
+            float _EnableExternalAlpha;
+            CBUFFER_END
+
+            CBUFFER_START(UnityPerDrawSpriteOutline)
+            #ifndef UNITY_INSTANCING_ENABLED
+            fixed4 _OutlineColor;
+            float _IsOutlineEnabled, _OutlineSize, _AlphaThreshold;
+            #endif
+            CBUFFER_END
+
+            sampler2D _MainTex, _AlphaTex;
+            float4 _MainTex_TexelSize;
+            fixed4 _Color;
+
+            struct VertexInput
+            {
+                float4 Vertex : POSITION;
+                float4 Color : COLOR;
+                float2 TexCoord : TEXCOORD0;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct VertexOutput
+            {
+                float4 Vertex : SV_POSITION;
+                fixed4 Color : COLOR;
+                float2 TexCoord : TEXCOORD0;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            VertexOutput ComputeVertex(VertexInput vertexInput)
+            {
+                VertexOutput vertexOutput;
+
+                UNITY_SETUP_INSTANCE_ID(vertexInput);
+                UNITY_TRANSFER_INSTANCE_ID(vertexInput, vertexOutput);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(vertexOutput);
+
+                #ifdef UNITY_INSTANCING_ENABLED
+                vertexInput.Vertex.xy *= _Flip;
+                #endif
+
+                vertexOutput.Vertex = UnityObjectToClipPos(vertexInput.Vertex);
+                vertexOutput.TexCoord = vertexInput.TexCoord;
+                vertexOutput.Color = vertexInput.Color * _Color * _RendererColor;
+
+                #ifdef PIXELSNAP_ON
+                vertexOutput.Vertex = UnityPixelSnap(vertexOutput.Vertex);
+                #endif
+
+                return vertexOutput;
+            }
+
+            // Determines whether _OutlineColor should replace sampledColor at the given texCoord when drawing inside the sprite borders.
+            // Will return 1 when the test is positive (should draw outline), 0 otherwise.
+            int ShouldDrawOutlineInside (fixed4 sampledColor, float2 texCoord, int isOutlineEnabled, int outlineSize, float alphaThreshold)
+            {
+                // Won't draw if effect is disabled, outline size is zero or sampled fragment is tranpsarent.
+                if (isOutlineEnabled * outlineSize * sampledColor.a == 0) return 0;
+
+                float2 texDdx = ddx(texCoord);
+                float2 texDdy = ddy(texCoord);
+
+                // Looking for a transparent pixel (sprite border from inside) around computed fragment with given depth (_OutlineSize).
+                // Also checking if sampled fragment is out of the texture space (UV is out of 0-1 range); considering such fragment as sprite border.
+                for (int i = 1; i <= SAMPLE_DEPTH_LIMIT; i++)
+                {
+                    float2 pixelUpTexCoord = texCoord + float2(0, i * _MainTex_TexelSize.y);
+                    fixed pixelUpAlpha = pixelUpTexCoord.y > 1.0 ? 0.0 : tex2Dgrad(_MainTex, pixelUpTexCoord, texDdx, texDdy).a;
+                    if (pixelUpAlpha <= alphaThreshold) return 1;
+
+                    float2 pixelDownTexCoord = texCoord - float2(0, i * _MainTex_TexelSize.y);
+                    fixed pixelDownAlpha = pixelDownTexCoord.y < 0.0 ? 0.0 : tex2Dgrad(_MainTex, pixelDownTexCoord, texDdx, texDdy).a;
+                    if (pixelDownAlpha <= alphaThreshold) return 1;
+
+                    float2 pixelRightTexCoord = texCoord + float2(i * _MainTex_TexelSize.x, 0);
+                    fixed pixelRightAlpha = pixelRightTexCoord.x > 1.0 ? 0.0 : tex2Dgrad(_MainTex, pixelRightTexCoord, texDdx, texDdy).a;
+                    if (pixelRightAlpha <= alphaThreshold) return 1;
+
+                    float2 pixelLeftTexCoord = texCoord - float2(i * _MainTex_TexelSize.x, 0);
+                    fixed pixelLeftAlpha = pixelLeftTexCoord.x < 0.0 ? 0.0 : tex2Dgrad(_MainTex, pixelLeftTexCoord, texDdx, texDdy).a;
+                    if (pixelLeftAlpha <= alphaThreshold) return 1;
+
+                    if (i > outlineSize) break;
+                }
+
+                return 0;
+            }
+
+            // Determines whether _OutlineColor should replace sampledColor at the given texCoord when drawing outside the sprite borders.
+            // Will return 1 when the test is positive (should draw outline), 0 otherwise.
+            int ShouldDrawOutlineOutside (fixed4 sampledColor, float2 texCoord, int isOutlineEnabled, int outlineSize, float alphaThreshold)
+            {
+                // Won't draw if effect is disabled, outline size is zero or sampled fragment is above alpha threshold.
+                if (isOutlineEnabled * outlineSize == 0) return 0;
+                if (sampledColor.a > alphaThreshold) return 0;
+
+                float2 texDdx = ddx(texCoord);
+                float2 texDdy = ddy(texCoord);
+
+                // Looking for an opaque pixel (sprite border from outise) around computed fragment with given depth (_OutlineSize).
+                for (int i = 1; i <= SAMPLE_DEPTH_LIMIT; i++)
+                {
+                    float2 pixelUpTexCoord = texCoord + float2(0, i * _MainTex_TexelSize.y);
+                    fixed pixelUpAlpha = tex2Dgrad(_MainTex, pixelUpTexCoord, texDdx, texDdy).a;
+                    if (pixelUpAlpha > alphaThreshold) return 1;
+
+                    float2 pixelDownTexCoord = texCoord - float2(0, i * _MainTex_TexelSize.y);
+                    fixed pixelDownAlpha = tex2Dgrad(_MainTex, pixelDownTexCoord, texDdx, texDdy).a;
+                    if (pixelDownAlpha > alphaThreshold) return 1;
+
+                    float2 pixelRightTexCoord = texCoord + float2(i * _MainTex_TexelSize.x, 0);
+                    fixed pixelRightAlpha = tex2Dgrad(_MainTex, pixelRightTexCoord, texDdx, texDdy).a;
+                    if (pixelRightAlpha > alphaThreshold) return 1;
+
+                    float2 pixelLeftTexCoord = texCoord - float2(i * _MainTex_TexelSize.x, 0);
+                    fixed pixelLeftAlpha = tex2Dgrad(_MainTex, pixelLeftTexCoord, texDdx, texDdy).a;
+                    if (pixelLeftAlpha > alphaThreshold) return 1;
+
+                    if (i > outlineSize) break;
+                }
+
+                return 0;
+            }
+
+            fixed4 SampleSpriteTexture(float2 uv)
+            {
+                fixed4 color = tex2D(_MainTex, uv);
+
+                #if ETC1_EXTERNAL_ALPHA
+                fixed4 alpha = tex2D(_AlphaTex, uv);
+                color.a = lerp(color.a, alpha.r, _EnableExternalAlpha);
+                #endif
+
+                return color;
+            }
+
+            fixed4 ComputeFragment(VertexOutput vertexOutput) : SV_Target
+            {
+                UNITY_SETUP_INSTANCE_ID(vertexOutput);
+
+                fixed4 color = SampleSpriteTexture(vertexOutput.TexCoord) * vertexOutput.Color;
+                color.rgb *= color.a;
+
+                int isOutlineEnabled = UNITY_ACCESS_INSTANCED_PROP(PerDrawSpriteOutline, _IsOutlineEnabled);
+                fixed4 outlineColor = UNITY_ACCESS_INSTANCED_PROP(PerDrawSpriteOutline, _OutlineColor);
+                int outlineSize = UNITY_ACCESS_INSTANCED_PROP(PerDrawSpriteOutline, _OutlineSize);
+                float alphaThreshold = UNITY_ACCESS_INSTANCED_PROP(PerDrawSpriteOutline, _AlphaThreshold);
+
+                #ifdef SPRITE_OUTLINE_OUTSIDE
+                int shouldDrawOutline = ShouldDrawOutlineOutside(color, vertexOutput.TexCoord, isOutlineEnabled, outlineSize, alphaThreshold);
+                #else
+                int shouldDrawOutline = ShouldDrawOutlineInside(color, vertexOutput.TexCoord, isOutlineEnabled, outlineSize, alphaThreshold);
+                #endif
+
+                color.rgb = lerp(color.rgb, outlineColor.rgb * outlineColor.a, shouldDrawOutline);
+
+                return color;
+            }
+
+            ENDCG
+        }
+    }
+}

--- a/Assets/SpriteGlow/SpriteOutline.shader.meta
+++ b/Assets/SpriteGlow/SpriteOutline.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: c20308b0e23b78d4c85098af31f19cb4
+timeCreated: 1473362089
+licenseType: Pro
+ShaderImporter:
+  defaultTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,4 +1,5 @@
 {
-	"dependencies": {
-	}
+  "dependencies": {
+    "com.unity.postprocessing": "2.1.6"
+  }
 }

--- a/ProjectSettings/GraphicsSettings.asset
+++ b/ProjectSettings/GraphicsSettings.asset
@@ -45,7 +45,109 @@ GraphicsSettings:
   m_TransparencySortAxis: {x: 0, y: 0, z: 1}
   m_DefaultRenderingPath: 1
   m_DefaultMobileRenderingPath: 1
-  m_TierSettings: []
+  m_TierSettings:
+  - serializedVersion: 5
+    m_BuildTarget: 4
+    m_Tier: 0
+    m_Settings:
+      standardShaderQuality: 0
+      renderingPath: 1
+      hdrMode: 2
+      realtimeGICPUUsage: 25
+      useReflectionProbeBoxProjection: 0
+      useReflectionProbeBlending: 0
+      useHDR: 1
+      useDetailNormalMap: 0
+      useCascadedShadowMaps: 0
+      prefer32BitShadowMaps: 0
+      enableLPPV: 0
+      useDitherMaskForAlphaBlendedShadows: 0
+    m_Automatic: 0
+  - serializedVersion: 5
+    m_BuildTarget: 4
+    m_Tier: 1
+    m_Settings:
+      standardShaderQuality: 1
+      renderingPath: 1
+      hdrMode: 2
+      realtimeGICPUUsage: 25
+      useReflectionProbeBoxProjection: 0
+      useReflectionProbeBlending: 0
+      useHDR: 1
+      useDetailNormalMap: 0
+      useCascadedShadowMaps: 0
+      prefer32BitShadowMaps: 0
+      enableLPPV: 0
+      useDitherMaskForAlphaBlendedShadows: 0
+    m_Automatic: 0
+  - serializedVersion: 5
+    m_BuildTarget: 4
+    m_Tier: 2
+    m_Settings:
+      standardShaderQuality: 1
+      renderingPath: 1
+      hdrMode: 2
+      realtimeGICPUUsage: 25
+      useReflectionProbeBoxProjection: 0
+      useReflectionProbeBlending: 0
+      useHDR: 1
+      useDetailNormalMap: 0
+      useCascadedShadowMaps: 0
+      prefer32BitShadowMaps: 0
+      enableLPPV: 0
+      useDitherMaskForAlphaBlendedShadows: 0
+    m_Automatic: 0
+  - serializedVersion: 5
+    m_BuildTarget: 7
+    m_Tier: 0
+    m_Settings:
+      standardShaderQuality: 0
+      renderingPath: 1
+      hdrMode: 2
+      realtimeGICPUUsage: 25
+      useReflectionProbeBoxProjection: 0
+      useReflectionProbeBlending: 0
+      useHDR: 1
+      useDetailNormalMap: 0
+      useCascadedShadowMaps: 0
+      prefer32BitShadowMaps: 0
+      enableLPPV: 0
+      useDitherMaskForAlphaBlendedShadows: 0
+    m_Automatic: 0
+  - serializedVersion: 5
+    m_BuildTarget: 7
+    m_Tier: 1
+    m_Settings:
+      standardShaderQuality: 1
+      renderingPath: 1
+      hdrMode: 2
+      realtimeGICPUUsage: 25
+      useReflectionProbeBoxProjection: 0
+      useReflectionProbeBlending: 0
+      useHDR: 1
+      useDetailNormalMap: 0
+      useCascadedShadowMaps: 0
+      prefer32BitShadowMaps: 0
+      enableLPPV: 0
+      useDitherMaskForAlphaBlendedShadows: 0
+    m_Automatic: 0
+  - serializedVersion: 5
+    m_BuildTarget: 7
+    m_Tier: 2
+    m_Settings:
+      standardShaderQuality: 1
+      renderingPath: 1
+      hdrMode: 2
+      realtimeGICPUUsage: 25
+      useReflectionProbeBoxProjection: 0
+      useReflectionProbeBlending: 0
+      useHDR: 1
+      useDetailNormalMap: 0
+      useCascadedShadowMaps: 0
+      prefer32BitShadowMaps: 0
+      enableLPPV: 0
+      useDitherMaskForAlphaBlendedShadows: 0
+    m_Automatic: 0
   m_LightmapStripping: 0
   m_FogStripping: 0
   m_InstancingStripping: 0

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -530,7 +530,19 @@ PlayerSettings:
   webGLUseEmbeddedResources: 0
   webGLCompressionFormat: 1
   webGLLinkerTarget: 0
-  scriptingDefineSymbols: {}
+  scriptingDefineSymbols:
+    1: UNITY_POST_PROCESSING_STACK_V2
+    4: UNITY_POST_PROCESSING_STACK_V2
+    7: UNITY_POST_PROCESSING_STACK_V2
+    13: UNITY_POST_PROCESSING_STACK_V2
+    17: UNITY_POST_PROCESSING_STACK_V2
+    18: UNITY_POST_PROCESSING_STACK_V2
+    19: UNITY_POST_PROCESSING_STACK_V2
+    21: UNITY_POST_PROCESSING_STACK_V2
+    23: UNITY_POST_PROCESSING_STACK_V2
+    25: UNITY_POST_PROCESSING_STACK_V2
+    26: UNITY_POST_PROCESSING_STACK_V2
+    27: UNITY_POST_PROCESSING_STACK_V2
   platformArchitecture: {}
   scriptingBackend: {}
   il2cppCompilerConfiguration: {}

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -18,7 +18,7 @@ TagManager:
   - UI
   - 
   - 
-  - 
+  - SpriteGlow
   - 
   - 
   - 


### PR DESCRIPTION
## 対象イシュー
https://app.mmth.pro/projects/18382/tasks#/show/230306

## 概要
- 数字パネルが最終タイルに存在することを分かりやすくするために，輝くようにした

- [Sprite Glow](https://github.com/Elringus/SpriteGlow) を利用した

## 技術的な内容
- Sprite Glow を利用するためには以下の条件が必要である．

1. [Post Processing](https://github.com/Unity-Technologies/PostProcessing) のインストール

2. `GraphicsSettings.asset` の対象デバイス（今回は，iOS と Android）において，HDR を利用可能にする

3. Sprite Glow 専用の Layer を用意する（今回は，`SpriteGlow` という名前の Layer ）

4. 対象シーンの Main Camera に Post Process Layer をアタッチし，Layer を `SpriteGlow` とする

5. 光らせたいオブジェクトに Post Process Volume をアタッチし，（今回は）`isGlobal` を `true` ，`Bloom` の設定が書かれた `profile` を指定する．`profile` の設定では，現状，`intensity` ，`Color` をいじっている

6. 最後に，光らせたいオブジェクトに `Sprite Glow` をアタッチする．パラメータは暫定で指定している

## キャプチャ
<img width="279" alt="スクリーンショット 2019-06-06 0 31 47" src="https://user-images.githubusercontent.com/26104258/58969411-a2856f80-87f2-11e9-975b-581f9a1471ab.png">

<img width="277" alt="スクリーンショット 2019-06-06 0 32 17" src="https://user-images.githubusercontent.com/26104258/58969428-aa451400-87f2-11e9-820b-8df44b9b3935.png">
