### PR TITLE
記録画面のグラフ目盛が正しく更新されない問題を修正

### DIFF
--- a/Assets/Project/Scripts/RecordScene/RecordDirector.cs
+++ b/Assets/Project/Scripts/RecordScene/RecordDirector.cs
@@ -137,9 +137,9 @@ namespace Project.Scripts.RecordScene
 			// 目盛を書き換える
 			if (maxScale > 0)
 			{
-				GameObject.Find("Scale4-Value").GetComponent<Text>().text = maxScale.ToString();
-				GameObject.Find("Scale3-Value").GetComponent<Text>().text = (maxScale * 2 / 3).ToString();
-				GameObject.Find("Scale2-Value").GetComponent<Text>().text = (maxScale / 3).ToString();
+				graphArea[stageLevel].transform.Find("Scale4-Value").gameObject.GetComponent<Text>().text = maxScale.ToString();
+				graphArea[stageLevel].transform.Find("Scale3-Value").gameObject.GetComponent<Text>().text = (maxScale * 2 / 3).ToString();
+				graphArea[stageLevel].transform.Find("Scale2-Value").gameObject.GetComponent<Text>().text = (maxScale / 3).ToString();
 			}
 
 			// ステージ番号


### PR DESCRIPTION
## 対象イシュー
https://app.mmth.pro/projects/18382/tasks#/show/242019

## 概要
> 多分このタスクで発生したわけではないバグについて。
RecordDirector.csの140行目のFind()で得られているのはEasyに置いてあるScale4-Valueだと思う。
簡単レベルのステージ１を60回とか、普通レベルのステージ1を60回プレイしても縦軸の最高回数が変わらないことが確認された。
レベル毎にloopして行われる記録画面の表示で、毎回簡単レベルのtextが上書きされてて、普通レベルのtextとかは上書きとかされてないのかな、と思う。
(他のtextはGetGamesObjects()でDictionaryに格納してるので問題ないと思う)

というコメントに，対応した．
グラフの目盛を `SnapScrollView` の変更の際に，正しくコード書き換え出来ていなかったことが問題．