### PR TITLE
ゲーム中にバックグラウンドに移動した旨が表示され続けるバグの改善

### DIFF
--- a/Assets/Project/Scripts/GamePlayScene/GamePlayDirector.cs
+++ b/Assets/Project/Scripts/GamePlayScene/GamePlayDirector.cs
@@ -61,6 +61,8 @@ namespace Project.Scripts.GamePlayScene
 
 			resultText = resultWindow.transform.Find(RESULT_NAME).gameObject;
 			warningText = resultWindow.transform.Find(WARNING_NAME).gameObject;
+			warningText.GetComponent<Text>().text = WARNING_TEXT;
+
 			stageNumberText = GameObject.Find(STAGE_NUMBER_TEXT_NAME);
 
 			UnifyDisplay(resultWindow);
@@ -79,7 +81,8 @@ namespace Project.Scripts.GamePlayScene
 			{
 				if (Dispatch(GameState.Failure))
 				{
-					warningText.GetComponent<Text>().text = WARNING_TEXT;
+					// 警告ウィンドウを表示
+					warningText.SetActive(true);
 				}
 			}
 		}
@@ -165,6 +168,9 @@ namespace Project.Scripts.GamePlayScene
 
 			// 結果ウィンドウを非表示
 			resultWindow.SetActive(false);
+
+			// 警告ウィンドウを非表示
+			warningText.SetActive(false);
 
 			// 番号に合わせたステージの作成
 			stageGenerator.GetComponent<StageGenerator>().CreateStages(stageId);


### PR DESCRIPTION
## 対象イシュー
https://app.mmth.pro/projects/18382/tasks#/show/240785

## 概要
ゲーム中にバックグラウンドに遷移した場合、失敗状態に遷移しつつ、その旨を表示している。
その後、リトライ時に単純にゲームルールに則り失敗した場合にも表示され続けてしまっている。
これを改善しました。

## 技術的な内容
１回目のゲーム開始時にも、リトライ時にも共通して呼ばれる
`GamePlayDirector.cs`の`GameOpening()`メソッド内で
警告テキストの表示を非表示に設定した。

## キャプチャ
