### PR TITLE
撃ち抜く銃弾がダミーパネルを撃ち抜いた時にゲーム失敗となる問題の改善

### DIFF
--- a/Assets/Project/Scenes/GamePlayScene_Profiles.meta
+++ b/Assets/Project/Scenes/GamePlayScene_Profiles.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 90b4ee6424aa34cb5857ab643ef24b3c
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/NormalHoleController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/NormalHoleController.cs
@@ -7,6 +7,9 @@ namespace Project.Scripts.GamePlayScene.Bullet
 {
 	public class NormalHoleController : BulletController
 	{
+		// 銃痕の表示時間
+		private const float HOLE_DISPLAYED_TIME = 0.50f;
+
 		protected int row;
 		protected int column;
 
@@ -47,7 +50,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
 				else
 				{
 					// 数字パネル以外のパネルが銃弾の出現場所に存在する
-					yield return new WaitForSeconds(0.5f);
+					yield return new WaitForSeconds(HOLE_DISPLAYED_TIME);
 					Destroy(gameObject);
 				}
 			}
@@ -56,7 +59,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
 				// 銃弾の出現場所にパネルが存在しない
 				// タイルとパネルの間のレイヤー(Hole)に描画する
 				gameObject.GetComponent<Renderer>().sortingLayerName = SortingLayerName.HOLE;
-				yield return new WaitForSeconds(0.5f);
+				yield return new WaitForSeconds(HOLE_DISPLAYED_TIME);
 				Destroy(gameObject);
 			}
 		}

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/NormalHoleController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/NormalHoleController.cs
@@ -37,12 +37,24 @@ namespace Project.Scripts.GamePlayScene.Bullet
 			// check whether panel exists on the tile
 			if (tile.transform.childCount != 0)
 			{
-				gameObject.GetComponent<SpriteRenderer>().color = Color.red;
-				gamePlayDirector.Dispatch(GamePlayDirector.GameState.Failure);
+				var panel = tile.transform.GetChild(0);
+				if (panel.CompareTag(TagName.NUMBER_PANEL))
+				{
+					// 数字パネルが銃弾の出現場所に存在する
+					gameObject.GetComponent<SpriteRenderer>().color = Color.red;
+					gamePlayDirector.Dispatch(GamePlayDirector.GameState.Failure);
+				}
+				else
+				{
+					// 数字パネル以外のパネルが銃弾の出現場所に存在する
+					yield return new WaitForSeconds(0.5f);
+					Destroy(gameObject);
+				}
 			}
 			else
 			{
-				// display the hole betweeen tile layer and panel layer
+				// 銃弾の出現場所にパネルが存在しない
+				// タイルとパネルの間のレイヤー(Hole)に描画する
 				gameObject.GetComponent<Renderer>().sortingLayerName = SortingLayerName.HOLE;
 				yield return new WaitForSeconds(0.5f);
 				Destroy(gameObject);


### PR DESCRIPTION

## 対象イシュー
https://app.mmth.pro/projects/18382/tasks#/show/240887

## 概要
撃ち抜く銃弾は、撃ち抜く瞬間に、撃ち抜くタイルの子供にパネルが存在しているかどうかで当たり判定を行っていた。
動く(動かない)ダミーパネルが実装されたことで、その判定方法では、ダミーパネルに対しても
当たり判定が置き、失敗状態に遷移してしまう。
この問題を改善し、数字パネルに対してのみ当たり判定を行うように変更した。

## 技術的な内容
撃ち抜く際に、タイルに子供が存在するか、存在するならば、数字パネルかどうかの判定を行うように変更した。
子供が存在しないならば、銃弾は、タイルより手前、かつ、パネルより後ろのレイヤーに配置される。
そのため、銃弾にかぶせるように別タイルを動かすと、銃弾は見えなくなる。
数字パネル以外のダミーパネルなどが存在するとき、銃弾は、パネルより手前のレイヤーに配置される。
そのため、ダミーパネルをその場所から別の場所に動かしても、銃弾は表示されたままである。
その後、銃弾が表示してある場所にパネルを再度動かすと、パネルより手前に銃弾が表示されることになる。
銃弾の継続出現時間は0.50秒であり、上記の２手をその時間内に行うことは難しく、基本的に再現されないので、特に問題視していない。

ダミーパネルが撃ち抜かれたとき、銃痕はダミーパネルに追随するのか、絶対的なタイル座標に残るのか（現在の仕様）、微妙なところではある。

1-4で動作確認可能。

## キャプチャ
静止画だと伝わらない。。。
ダミーを撃ち抜かれた瞬間に、ダミー動かすとタイル上に銃痕残る仕様です。