### PR TITLE
ゲームリトライ時にBulletGroupGenerator の初期化処理を記述する

### DIFF
--- a/Assets/Project/Scripts/GamePlayScene/Bullet/BulletGroupController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/BulletGroupController.cs
@@ -90,7 +90,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
 				}
 				catch (OverflowException)
 				{
-					gamePlayDirector.Dispatch(GamePlayDirector.GameState.Failure);
+					bulletGroupGenerator.bulletId = short.MinValue;
 				}
 
 				// 次の銃弾を作成する時刻まで待つ

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/BulletGroupGenerator.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/BulletGroupGenerator.cs
@@ -8,7 +8,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
 	public class BulletGroupGenerator : MonoBehaviour
 	{
 		// 生成された銃弾のID(sortingOrder)
-		public short bulletId = -32768;
+		public short bulletId;
 
 		// 銃弾グループを制御するcoroutine
 		private List<IEnumerator> coroutines;
@@ -40,10 +40,17 @@ namespace Project.Scripts.GamePlayScene.Bullet
 		/* 一連の銃弾の生成タイミングを管理するBulletGroupを作成する */
 		public void CreateBulletGroups(List<IEnumerator> coroutines)
 		{
-			this.coroutines = coroutines;
-			startTime = Time.time;
+			Initialize();
 
+			this.coroutines = coroutines;
 			foreach (var coroutine in this.coroutines) StartCoroutine(coroutine);
+		}
+
+		/* ゲーム開始時およびリトライ時に初期化が必要な変数を初期化する */
+		private void Initialize()
+		{
+			bulletId = short.MaxValue - 2;//short.MinValue;
+			startTime = Time.time;
 		}
 
 		/* BulletGroupを生成する */

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/BulletGroupGenerator.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/BulletGroupGenerator.cs
@@ -49,7 +49,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
 		/* ゲーム開始時およびリトライ時に初期化が必要な変数を初期化する */
 		private void Initialize()
 		{
-			bulletId = short.MaxValue - 2;//short.MinValue;
+			bulletId = short.MinValue;
 			startTime = Time.time;
 		}
 


### PR DESCRIPTION
## 対象イシュー
Close #72

## 概要
- ゲーム開始時およびゲームリトライ時に`BulletGroupGenerator`内の初期化が必要な変数を初期化する
- 銃弾の`sortingOrder`(同一レイヤー内で描画する順番)を指定する`bulletId`がオーバーフローしたときに、ゲーム失敗状態に遷移するのではなく、値に`short`型の最小値を入れる。

## 技術的な内容
- 後に出現する銃弾ほど、手前に描画されるようになっています。しかし、オーバーフローした場合(`65536+1`個以上の銃弾が１ゲーム内で出現した場合)には、オーバーフロー後に出現した銃弾が奥側に描画されます。

## キャプチャ
オーバーフロー後の銃弾の描画順序の図。
![image001](https://user-images.githubusercontent.com/26213141/61577151-25058c80-ab1e-11e9-8594-966f7a39363d.png)