### PR TITLE
エディタ実行中以外は ToggleValueChanged を無視する

### DIFF
--- a/Assets/Project/Scripts/MenuSelectScene/MenuSelectToggle.cs
+++ b/Assets/Project/Scripts/MenuSelectScene/MenuSelectToggle.cs
@@ -18,16 +18,24 @@ namespace Project.Scripts.MenuSelectScene
 
         private void ToggleValueChanged(GameObject toggle)
         {
+            #if UNITY_EDITOR
+                if (!EditorApplication.isPlaying) return;
+            #endif
+
             // ONになった場合のみ処理
-            if (isOn && EditorApplication.isPlaying) {
+            if (isOn) {
                 var nowScene = MenuSelectDirector.Instance.NowScene;
+
                 // 現在チェックされている Toggle を取得
                 var checkedToggle = GameObject.Find(nowScene.Replace("Scene", ""));
-                checkedToggle.GetComponent<MenuSelectToggle>().isOn = false;
-                // 今のシーンをアンロード
-                SceneManager.UnloadSceneAsync(nowScene);
-                // 新しいシーンをロード
-                StartCoroutine(MenuSelectDirector.Instance.AddScene(name + "Scene"));
+
+                if (checkedToggle != null) {
+                    checkedToggle.GetComponent<MenuSelectToggle>().isOn = false;
+                    // 今のシーンをアンロード
+                    SceneManager.UnloadSceneAsync(nowScene);
+                    // 新しいシーンをロード
+                    StartCoroutine(MenuSelectDirector.Instance.AddScene(name + "Scene"));
+                }
             }
         }
 

--- a/Assets/Project/Scripts/MenuSelectScene/MenuSelectToggle.cs
+++ b/Assets/Project/Scripts/MenuSelectScene/MenuSelectToggle.cs
@@ -19,7 +19,7 @@ namespace Project.Scripts.MenuSelectScene
         private void ToggleValueChanged(GameObject toggle)
         {
             #if UNITY_EDITOR
-                if (!EditorApplication.isPlaying) return;
+            if (!EditorApplication.isPlaying) return;
             #endif
 
             // ONになった場合のみ処理

--- a/Assets/Project/Scripts/MenuSelectScene/MenuSelectToggle.cs
+++ b/Assets/Project/Scripts/MenuSelectScene/MenuSelectToggle.cs
@@ -1,11 +1,10 @@
-﻿using Project.Scripts.MenuSelectScene;
 ﻿using UnityEditor;
 using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.SceneManagement;
 using UnityEngine.UI;
 
-namespace Project.Scripts.Utils.MyUiConponents
+namespace Project.Scripts.MenuSelectScene
 {
     public class MenuSelectToggle : Toggle
     {

--- a/Assets/Project/Scripts/MenuSelectScene/MenuSelectToggle.cs
+++ b/Assets/Project/Scripts/MenuSelectScene/MenuSelectToggle.cs
@@ -1,4 +1,5 @@
 ﻿using Project.Scripts.MenuSelectScene;
+﻿using UnityEditor;
 using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.SceneManagement;
@@ -19,17 +20,15 @@ namespace Project.Scripts.Utils.MyUiConponents
         private void ToggleValueChanged(GameObject toggle)
         {
             // ONになった場合のみ処理
-            if (isOn) {
+            if (isOn && EditorApplication.isPlaying) {
                 var nowScene = MenuSelectDirector.Instance.NowScene;
                 // 現在チェックされている Toggle を取得
                 var checkedToggle = GameObject.Find(nowScene.Replace("Scene", ""));
-                if (checkedToggle != null) {
-                    checkedToggle.GetComponent<MenuSelectToggle>().isOn = false;
-                    // 今のシーンをアンロード
-                    SceneManager.UnloadSceneAsync(nowScene);
-                    // 新しいシーンをロード
-                    StartCoroutine(MenuSelectDirector.Instance.AddScene(name + "Scene"));
-                }
+                checkedToggle.GetComponent<MenuSelectToggle>().isOn = false;
+                // 今のシーンをアンロード
+                SceneManager.UnloadSceneAsync(nowScene);
+                // 新しいシーンをロード
+                StartCoroutine(MenuSelectDirector.Instance.AddScene(name + "Scene"));
             }
         }
 


### PR DESCRIPTION
## 対象イシュー
急遽作成

## 概要
#152 で対処療法を行なったが，エディタ終了時にも同じエラーが出てウザかったので，エディタ実行中以外は無視するようにした．

## 技術的な内容
`EditorApplication.isPlaying` は実行中．

↓ 参考 URL
http://kan-kikuchi.hatenablog.com/entry/PlaymodeStateObserver

