### PR TITLE
記録画面のリファクタリングと描画時の非同期処理の検討

### DIFF
--- a/Assets/Project/Scripts/RecordScene/RecordDirector.cs
+++ b/Assets/Project/Scripts/RecordScene/RecordDirector.cs
@@ -59,7 +59,6 @@ namespace Project.Scripts.RecordScene
             // ページの横幅の設定
             _snapScrollView.PageSize = Screen.width;
 
-            // TODO: 将来的には非同期で呼び出したい (バージョンアップ待ち)
             // 各種グラフなどを全て描画する
             Draw();
         }

--- a/Assets/Project/Scripts/RecordScene/RecordDirector.cs
+++ b/Assets/Project/Scripts/RecordScene/RecordDirector.cs
@@ -64,11 +64,13 @@ namespace Project.Scripts.RecordScene
             Draw();
         }
 
-        /* 全難易度の画面を描画する */
+        /// <summary>
+        /// 全難易度の画面を描画する
+        /// </summary>
         private void Draw()
         {
             foreach (EStageLevel stageLevel in Enum.GetValues(typeof(EStageLevel))) {
-                // 準備
+                // GameObject の準備
                 GetGameObjects(stageLevel);
                 // タイトルの変更
                 _levelText[stageLevel].GetComponent<Text>().text = StageInfo.LevelName[stageLevel];
@@ -79,19 +81,27 @@ namespace Project.Scripts.RecordScene
             }
         }
 
-        /* 必要な GameObject を Scene から取得 */
+        /// <summary>
+        /// 各難易度に必要な GameObject を取得
+        /// </summary>
+        /// <param name="stageLevel"> 難易度 </param>
         private void GetGameObjects(EStageLevel stageLevel)
         {
-            // SnapScrollView -> Viewport -> Content -> のオブジェクトを特定
+            // Canvas -> SnapScrollView -> Viewport -> Content -> ${stageLevel} を取得
             var level = GameObject.Find(stageLevel.ToString()).transform;
 
-            // 各種 GameObject を取得
+            // ${stageLevel} -> Level を取得
             _levelText.Add(stageLevel, level.Find("Level").gameObject);
+            // ${stageLevel} -> Percentage を取得
             _percentageText.Add(stageLevel, level.Find("Percentage").gameObject);
+            // ${stageLevel} -> GraphArea を取得
             _graphArea.Add(stageLevel, level.Find("GraphArea").gameObject);
         }
 
-        /* 難易度に合わせた成功割合を描画する */
+        /// <summary>
+        /// 難易度に合わせた成功割合を描画する
+        /// </summary>
+        /// <param name="stageLevel"> 難易度 </param>
         private void DrawPercentage(EStageLevel stageLevel)
         {
             var stageNum = StageInfo.Num[stageLevel];
@@ -112,7 +122,10 @@ namespace Project.Scripts.RecordScene
             _percentageText[stageLevel].GetComponent<Text>().text = successPercentage + "%";
         }
 
-        /* 難易度に合わせた棒グラフを描画する */
+        /// <summary>
+        /// 難易度に合わせた棒グラフを描画する
+        /// </summary>
+        /// <param name="stageLevel"> 難易度 </param>
         private void DrawGraph(EStageLevel stageLevel)
         {
             var stageNum = StageInfo.Num[stageLevel];
@@ -130,7 +143,7 @@ namespace Project.Scripts.RecordScene
             // 挑戦回数の最大値を求める
             var maxChallengeNum = GetMaxChallengeNum(stageNum, stageStartId);
 
-            // 目盛の最大値を求める
+            // 挑戦回数の最大値に収まる 30 で割れる目盛の最小値を求める
             var maxScale = (float) Math.Ceiling((float) maxChallengeNum / 30) * 30;
 
             // 目盛を書き換える
@@ -196,7 +209,12 @@ namespace Project.Scripts.RecordScene
             }
         }
 
-        /* 挑戦回数の最大値を求める */
+        /// <summary>
+        /// 挑戦回数の最大値を求める
+        /// </summary>
+        /// <param name="stageNum"></param>
+        /// <param name="stageStartId"></param>
+        /// <returns></returns>
         private static int GetMaxChallengeNum(int stageNum, int stageStartId)
         {
             var maxChallengeNum = 0;

--- a/Assets/Project/Scripts/RecordScene/RecordDirector.cs
+++ b/Assets/Project/Scripts/RecordScene/RecordDirector.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using Project.Scripts.Utils.Definitions;
 using Project.Scripts.Utils.PlayerPrefsUtils;
@@ -60,13 +61,13 @@ namespace Project.Scripts.RecordScene
             _snapScrollView.PageSize = Screen.width;
 
             // 各種グラフなどを全て描画する
-            Draw();
+            StartCoroutine(Draw());
         }
 
         /// <summary>
         /// 全難易度の画面を描画する
         /// </summary>
-        private void Draw()
+        private IEnumerator Draw()
         {
             foreach (EStageLevel stageLevel in Enum.GetValues(typeof(EStageLevel))) {
                 // GameObject の準備

--- a/Assets/Project/Scripts/RecordScene/RecordDirector.cs
+++ b/Assets/Project/Scripts/RecordScene/RecordDirector.cs
@@ -16,22 +16,22 @@ namespace Project.Scripts.RecordScene
 
         [SerializeField] private GameObject _successLinePrefab;
 
-        private readonly Dictionary<EStageLevel, GameObject> levelText = new Dictionary<EStageLevel, GameObject>();
+        private readonly Dictionary<EStageLevel, GameObject> _levelText = new Dictionary<EStageLevel, GameObject>();
 
-        private readonly Dictionary<EStageLevel, GameObject> percentageText = new Dictionary<EStageLevel, GameObject>();
+        private readonly Dictionary<EStageLevel, GameObject> _percentageText = new Dictionary<EStageLevel, GameObject>();
 
-        private readonly Dictionary<EStageLevel, GameObject> graphArea = new Dictionary<EStageLevel, GameObject>();
+        private readonly Dictionary<EStageLevel, GameObject> _graphArea = new Dictionary<EStageLevel, GameObject>();
 
-        private SnapScrollView snapScrollView;
+        private SnapScrollView _snapScrollView;
 
         private void Awake()
         {
             // 取得
-            snapScrollView = GameObject.Find("SnapScrollView").GetComponent<SnapScrollView>();
+            _snapScrollView = GameObject.Find("SnapScrollView").GetComponent<SnapScrollView>();
             // ページの最大値を設定
-            snapScrollView.MaxPage = Enum.GetNames(typeof(EStageLevel)).Length - 1;
+            _snapScrollView.MaxPage = Enum.GetNames(typeof(EStageLevel)).Length - 1;
             // ページの横幅の設定
-            snapScrollView.PageSize = Screen.width;
+            _snapScrollView.PageSize = Screen.width;
 
             // TODO: 将来的には非同期で呼び出したい (バージョンアップ待ち)
             // 各種グラフなどを全て描画する
@@ -49,7 +49,7 @@ namespace Project.Scripts.RecordScene
                 // 棒グラフの描画
                 DrawGraph(stageLevel);
                 // タイトルの変更
-                levelText[stageLevel].GetComponent<Text>().text = StageInfo.LevelName[stageLevel];
+                _levelText[stageLevel].GetComponent<Text>().text = StageInfo.LevelName[stageLevel];
             }
         }
 
@@ -60,9 +60,9 @@ namespace Project.Scripts.RecordScene
             var level = GameObject.Find(stageLevel.ToString());
 
             // 各種 GameObject を取得
-            levelText.Add(stageLevel, level.transform.Find("Level").gameObject);
-            percentageText.Add(stageLevel, level.transform.Find("Percentage").gameObject);
-            graphArea.Add(stageLevel, level.transform.Find("GraphArea").gameObject);
+            _levelText.Add(stageLevel, level.transform.Find("Level").gameObject);
+            _percentageText.Add(stageLevel, level.transform.Find("Percentage").gameObject);
+            _graphArea.Add(stageLevel, level.transform.Find("GraphArea").gameObject);
         }
 
         /* 難易度に合わせた成功割合を描画する */
@@ -83,7 +83,7 @@ namespace Project.Scripts.RecordScene
 
             var successPercentage = (successStageNum / (float) stageNum) * 100;
 
-            percentageText[stageLevel].GetComponent<Text>().text = successPercentage + "%";
+            _percentageText[stageLevel].GetComponent<Text>().text = successPercentage + "%";
         }
 
         /* 難易度に合わせた棒グラフを描画する */
@@ -114,6 +114,7 @@ namespace Project.Scripts.RecordScene
 
             // ステージ番号の下端
             const float bottomStageNumPosition = 0.05f;
+            var graphAreaContent = _graphArea[stageLevel].GetComponent<RectTransform>();
 
             // グラフ間の隙間の横幅 -> stageNum個のグラフと(stageNum + 1)個の隙間
             var blankWidth = (rightPosition - leftPosition) / (stageNum * graphWidthRatio + (stageNum + 1));
@@ -129,9 +130,9 @@ namespace Project.Scripts.RecordScene
 
             // 目盛を書き換える
             if (maxScale > 0) {
-                graphArea[stageLevel].transform.Find("Scale4-Value").gameObject.GetComponent<Text>().text = maxScale.ToString();
-                graphArea[stageLevel].transform.Find("Scale3-Value").gameObject.GetComponent<Text>().text = (maxScale * 2 / 3).ToString();
-                graphArea[stageLevel].transform.Find("Scale2-Value").gameObject.GetComponent<Text>().text = (maxScale / 3).ToString();
+                _graphArea[stageLevel].transform.Find("Scale4-Value").gameObject.GetComponent<Text>().text = maxScale.ToString();
+                _graphArea[stageLevel].transform.Find("Scale3-Value").gameObject.GetComponent<Text>().text = (maxScale * 2 / 3).ToString();
+                _graphArea[stageLevel].transform.Find("Scale2-Value").gameObject.GetComponent<Text>().text = (maxScale / 3).ToString();
             }
 
             // ステージ番号

--- a/Assets/Project/Scripts/RecordScene/RecordDirector.cs
+++ b/Assets/Project/Scripts/RecordScene/RecordDirector.cs
@@ -61,24 +61,31 @@ namespace Project.Scripts.RecordScene
             _snapScrollView.PageSize = Screen.width;
 
             // 各種グラフなどを全て描画する
-            StartCoroutine(Draw());
+            Draw();
         }
 
         /// <summary>
         /// 全難易度の画面を描画する
         /// </summary>
-        private IEnumerator Draw()
+        private void Draw()
         {
-            foreach (EStageLevel stageLevel in Enum.GetValues(typeof(EStageLevel))) {
-                // GameObject の準備
-                GetGameObjects(stageLevel);
-                // タイトルの変更
-                _levelText[stageLevel].GetComponent<Text>().text = StageInfo.LevelName[stageLevel];
-                // 成功割合の描画
-                DrawPercentage(stageLevel);
-                // 棒グラフの描画
-                DrawGraph(stageLevel);
-            }
+            foreach (EStageLevel stageLevel in Enum.GetValues(typeof(EStageLevel))) StartCoroutine(DrawEach(stageLevel));
+        }
+
+        /// <summary>
+        /// 各難易度の画面を描画する
+        /// </summary>
+        /// <param name="stageLevel"> 難易度 </param>
+        private IEnumerator DrawEach(EStageLevel stageLevel)
+        {
+            // GameObject の準備
+            GetGameObjects(stageLevel);
+            // タイトルの変更
+            _levelText[stageLevel].GetComponent<Text>().text = StageInfo.LevelName[stageLevel];
+            // 成功割合の描画
+            DrawPercentage(stageLevel);
+            // 棒グラフの描画
+            DrawGraph(stageLevel);
         }
 
         /// <summary>

--- a/Assets/Project/Scripts/RecordScene/RecordDirector.cs
+++ b/Assets/Project/Scripts/RecordScene/RecordDirector.cs
@@ -24,6 +24,32 @@ namespace Project.Scripts.RecordScene
 
         private SnapScrollView _snapScrollView;
 
+        /* 以下，グラフ描画 UI 周りの配置設定 */
+
+        // 棒グラフ描画範囲の左端
+        private const float LEFT_POSITION = 0.1f;
+
+        // 棒グラフ描画範囲の右端
+        private const float RIGHT_POSITION = 0.95f;
+
+        // 棒グラフ本体の上端
+        private const float TOP_POSITION = 0.9f;
+
+        // 棒グラフ本体の下端
+        private const float BOTTOM_POSITION = 0.15f;
+
+        // 棒グラフの横幅が隙間の何倍か
+        private const float GRAPH_WIDTH_RATIO = 1.0f;
+
+        // ステージ番号の下端
+        private const float BOTTOM_STAGE_NUM_POSITION = 0.05f;
+
+        // 成功している場合のグラフの色
+        [SerializeField] private Color _successGraphColor = Color.cyan;
+
+        // 成功していない場合のグラフの色
+        [SerializeField] private Color _notSuccessGraphColor = Color.red;
+
         private void Awake()
         {
             // 取得
@@ -93,32 +119,13 @@ namespace Project.Scripts.RecordScene
             var stageStartId = StageInfo.StageStartId[stageLevel];
 
             // 描画するパネル
-            /* UIの配置周りの定数宣言 */
-
-            // 棒グラフ描画範囲の左端
-            const float leftPosition = 0.1f;
-
-            // 棒グラフ描画範囲の右端
-            const float rightPosition = 0.95f;
-
-            // 棒グラフ本体の上端
-            const float topPosition = 0.9f;
-
-            // 棒グラフ本体の下端
-            const float bottomPosition = 0.15f;
-
-            // 棒グラフの横幅が隙間の何倍か
-            const float graphWidthRatio = 1.0f;
-
-            // ステージ番号の下端
-            const float bottomStageNumPosition = 0.05f;
             var graphAreaContent = _graphArea[stageLevel].GetComponent<RectTransform>();
 
             // グラフ間の隙間の横幅 -> stageNum個のグラフと(stageNum + 1)個の隙間
-            var blankWidth = (rightPosition - leftPosition) / (stageNum * graphWidthRatio + (stageNum + 1));
+            var blankWidth = (RIGHT_POSITION - LEFT_POSITION) / (stageNum * GRAPH_WIDTH_RATIO + (stageNum + 1));
 
             // 棒グラフの横幅
-            var graphWidth = blankWidth * graphWidthRatio;
+            var graphWidth = blankWidth * GRAPH_WIDTH_RATIO;
 
             // 挑戦回数の最大値を求める
             var maxChallengeNum = GetMaxChallengeNum(stageNum, stageStartId);
@@ -136,7 +143,7 @@ namespace Project.Scripts.RecordScene
             // ステージ番号
             var stageName = 1;
             // 描画する棒グラフの左端を示す
-            var left = leftPosition;
+            var left = LEFT_POSITION;
 
             for (var stageId = stageStartId; stageId < stageStartId + stageNum; stageId++) {
                 // 左端と右端の更新
@@ -149,37 +156,37 @@ namespace Project.Scripts.RecordScene
                 var stageNumUi = Instantiate(_stageNumPrefab);
                 stageNumUi.transform.SetParent(graphAreaContent, false);
                 stageNumUi.GetComponent<Text>().text = stageName.ToString();
-                stageNumUi.GetComponent<RectTransform>().anchorMin = new Vector2(left, bottomStageNumPosition);
-                stageNumUi.GetComponent<RectTransform>().anchorMax = new Vector2(right, bottomPosition);
+                stageNumUi.GetComponent<RectTransform>().anchorMin = new Vector2(left, BOTTOM_STAGE_NUM_POSITION);
+                stageNumUi.GetComponent<RectTransform>().anchorMax = new Vector2(right, BOTTOM_POSITION);
 
                 /* 棒グラフの配置 */
                 var graphUi = Instantiate(_graphPrefab);
                 graphUi.transform.SetParent(graphAreaContent, false);
 
                 // 挑戦回数に応じた棒グラフの上端
-                var graphMaxY = bottomPosition;
+                var graphMaxY = BOTTOM_POSITION;
 
                 if (maxChallengeNum != 0) {
                     // 挑戦回数を用いて，棒グラフの高さを描画範囲に正規化する
-                    graphMaxY = (topPosition - bottomPosition) * (stageStatus.challengeNum / maxScale) + bottomPosition;
+                    graphMaxY = (TOP_POSITION - BOTTOM_POSITION) * (stageStatus.challengeNum / maxScale) + BOTTOM_POSITION;
                 }
 
-                graphUi.GetComponent<RectTransform>().anchorMin = new Vector2(left, bottomPosition);
+                graphUi.GetComponent<RectTransform>().anchorMin = new Vector2(left, BOTTOM_POSITION);
                 graphUi.GetComponent<RectTransform>().anchorMax = new Vector2(right, graphMaxY);
 
                 if (stageStatus.passed) {
                     /* 成功している場合は，色を水色にして，成功した際の挑戦回数も示す */
-                    graphUi.GetComponent<Image>().color = Color.cyan;
+                    graphUi.GetComponent<Image>().color = _successGraphColor;
 
                     var successLineUi = Instantiate(_successLinePrefab);
                     successLineUi.transform.SetParent(graphAreaContent, false);
-                    var successY = (topPosition - bottomPosition) * (stageStatus.firstSuccessNum / maxScale) +
-                        bottomPosition;
+                    var successY = (TOP_POSITION - BOTTOM_POSITION) * (stageStatus.firstSuccessNum / maxScale) +
+                        BOTTOM_POSITION;
                     successLineUi.GetComponent<RectTransform>().anchorMin = new Vector2(left, successY);
                     successLineUi.GetComponent<RectTransform>().anchorMax = new Vector2(right, successY);
                 } else {
                     /* 成功していない場合は，色を赤色にする */
-                    graphUi.GetComponent<Image>().color = Color.red;
+                    graphUi.GetComponent<Image>().color = _notSuccessGraphColor;
                 }
 
                 // 左端の更新

--- a/Assets/Project/Scripts/RecordScene/RecordDirector.cs
+++ b/Assets/Project/Scripts/RecordScene/RecordDirector.cs
@@ -93,8 +93,6 @@ namespace Project.Scripts.RecordScene
             var stageStartId = StageInfo.StageStartId[stageLevel];
 
             // 描画するパネル
-            var graphAreaContent = graphArea[stageLevel].GetComponent<RectTransform>();
-
             /* UIの配置周りの定数宣言 */
 
             // 棒グラフ描画範囲の左端

--- a/Assets/Project/Scripts/RecordScene/RecordDirector.cs
+++ b/Assets/Project/Scripts/RecordScene/RecordDirector.cs
@@ -27,7 +27,7 @@ namespace Project.Scripts.RecordScene
         private void Awake()
         {
             // 取得
-            _snapScrollView = GameObject.Find("SnapScrollView").GetComponent<SnapScrollView>();
+            _snapScrollView = FindObjectOfType<SnapScrollView>();
             // ページの最大値を設定
             _snapScrollView.MaxPage = Enum.GetNames(typeof(EStageLevel)).Length - 1;
             // ページの横幅の設定
@@ -57,12 +57,12 @@ namespace Project.Scripts.RecordScene
         private void GetGameObjects(EStageLevel stageLevel)
         {
             // SnapScrollView -> Viewport -> Content -> のオブジェクトを特定
-            var level = GameObject.Find(stageLevel.ToString());
+            var level = GameObject.Find(stageLevel.ToString()).transform;
 
             // 各種 GameObject を取得
-            _levelText.Add(stageLevel, level.transform.Find("Level").gameObject);
-            _percentageText.Add(stageLevel, level.transform.Find("Percentage").gameObject);
-            _graphArea.Add(stageLevel, level.transform.Find("GraphArea").gameObject);
+            _levelText.Add(stageLevel, level.Find("Level").gameObject);
+            _percentageText.Add(stageLevel, level.Find("Percentage").gameObject);
+            _graphArea.Add(stageLevel, level.Find("GraphArea").gameObject);
         }
 
         /* 難易度に合わせた成功割合を描画する */

--- a/Assets/Project/Scripts/RecordScene/RecordDirector.cs
+++ b/Assets/Project/Scripts/RecordScene/RecordDirector.cs
@@ -70,12 +70,12 @@ namespace Project.Scripts.RecordScene
             foreach (EStageLevel stageLevel in Enum.GetValues(typeof(EStageLevel))) {
                 // 準備
                 GetGameObjects(stageLevel);
+                // タイトルの変更
+                _levelText[stageLevel].GetComponent<Text>().text = StageInfo.LevelName[stageLevel];
                 // 成功割合の描画
                 DrawPercentage(stageLevel);
                 // 棒グラフの描画
                 DrawGraph(stageLevel);
-                // タイトルの変更
-                _levelText[stageLevel].GetComponent<Text>().text = StageInfo.LevelName[stageLevel];
             }
         }
 

--- a/Assets/Project/Scripts/RecordScene/RecordDirector.cs
+++ b/Assets/Project/Scripts/RecordScene/RecordDirector.cs
@@ -86,6 +86,8 @@ namespace Project.Scripts.RecordScene
             DrawPercentage(stageLevel);
             // 棒グラフの描画
             DrawGraph(stageLevel);
+
+            yield return null;
         }
 
         /// <summary>


### PR DESCRIPTION
## 対象イシュー
Close #110 

## 概要
- 記録画面のリファクタリングを行なった
- グラフなどの画面描画における非同期処理の検討

## 技術的な内容
#### 非同期処理に関して
現状，非同期処理を見送る方針でいる．
理由は，原則として非同期処理はメインスレッド（UIスレッド）の動作を維持するために行う．
しかし，記録画面における描画はUIを扱う．そもそも，メインスレッド以外のスレッドでは，`Find()`，`GetComponent<>()`などが利用できない．加えて`PlayerPrefs`も利用できない．そのため，描画する処理（`Draw()`メソッド）を非同期に行うことが現状できない．
今後の方針としては，
- 描画に `Find()`，`GetComponent<>()`が伴う場合には，非同期処理にはしない
- 非同期処理にできる部分だけうまく抽出して非同期処理にする

ということになると思う．ここについて議論できたらと思う．
