### PR TITLE
fix compiler error caused of CreateAimingHoleGenerator

### DIFF
--- a/Assets/Project/Scripts/GamePlayScene/StageGenerator.cs
+++ b/Assets/Project/Scripts/GamePlayScene/StageGenerator.cs
@@ -345,10 +345,7 @@ namespace Project.Scripts.GamePlayScene
                         bulletGroupGenerator.CreateNormalCartridgeGenerator(ratio: 10,
                             cartridgeDirection: ECartridgeDirection.Random, row: ERow.Random),
                                                 bulletGroupGenerator.CreateTurnCartridgeGenerator(ratio: 10,
-                                                    cartridgeDirection: ECartridgeDirection.Random, row: ERow.Random),
-                                                bulletGroupGenerator.CreateNormalHoleGenerator(ratio: 10, row: ERow.Random,
-                                                    column: EColumn.Random),
-                                                bulletGroupGenerator.CreateAimingHoleGenerator(ratio: 10)
+                                                    cartridgeDirection: ECartridgeDirection.Random, row: ERow.Random)
                     }));
                     /* 特殊タイル -> 数字パネル -> 特殊パネル */
                     // 数字パネル作成


### PR DESCRIPTION
## 対象イシュー

なし

## 概要

`CreateAimingholeGenerator` の引数が変更されたけど変更せずにマージしたらエラーが出た
ちょうど `Aiminghole` がテストステージでは邪魔だったのでこの機にAimingholeを退場させた

## 技術的な内容

バグ修正

## キャプチャ

