### PR TITLE
曲がる銃弾が，曲がった直後のタイル上で再度曲がる場合に警告画像の表示が遅い問題の修正

### DIFF
--- a/Assets/Project/Scripts/GamePlayScene/Bullet/BulletGroupGenerator.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/BulletGroupGenerator.cs
@@ -167,7 +167,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
         {
             var cartridgeGenerator = Instantiate(_turnCartridgeGeneratorPrefab);
             var cartridgeGeneratorScript = cartridgeGenerator.GetComponent<TurnCartridgeGenerator>();
-            cartridgeGeneratorScript.Initialize(ratio, cartridgeDirection, row);
+            cartridgeGeneratorScript.Initialize(ratio, cartridgeDirection, row, turnDirection, turnLine);
             return cartridgeGenerator;
         }
 
@@ -187,7 +187,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
         {
             var cartridgeGenerator = Instantiate(_turnCartridgeGeneratorPrefab);
             var cartridgeGeneratorScript = cartridgeGenerator.GetComponent<TurnCartridgeGenerator>();
-            cartridgeGeneratorScript.Initialize(ratio, cartridgeDirection, column);
+            cartridgeGeneratorScript.Initialize(ratio, cartridgeDirection, column, turnDirection, turnLine);
             return cartridgeGenerator;
         }
 

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/TurnCartridgeController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/TurnCartridgeController.cs
@@ -24,6 +24,8 @@ namespace Project.Scripts.GamePlayScene.Bullet
         /// </summary>
         [SerializeField] private GameObject _normalCartridgeWarningPrefab;
 
+        private GamePlayDirector _gamePlayDirector;
+
         /// <summary>
         /// 警告を表示するフレームの配列
         /// </summary>
@@ -32,7 +34,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
         /// <summary>
         /// 次に表示する警告のインデックス
         /// </summary>
-        private int warningIndex = 0;
+        private int _warningIndex = 0;
 
         /// <summary>
         /// 曲がる方向を示す警告の座標の配列
@@ -81,23 +83,32 @@ namespace Project.Scripts.GamePlayScene.Bullet
             turnBottom
         }
 
+        protected override void Awake()
+        {
+            base.Awake();
+            _gamePlayDirector = FindObjectOfType<GamePlayDirector>();
+        }
+
         protected override void FixedUpdate()
         {
-            // 警告を表示するタイミングかどうかを毎フレーム監視する
-            _warningTiming[warningIndex]--;
-            if (_warningTiming[warningIndex] == 0) {
-                // 警告を表示、その後、銃弾の回転
-                StartCoroutine(rotateCoroutines[warningIndex]);
-                // 次の警告の表示タイミングを監視する
-                warningIndex++;
-            }
+            if (_gamePlayDirector.state == GamePlayDirector.EGameState.Playing) {
+                // 警告を表示するタイミングかどうかを毎フレーム監視する
+                _warningTiming[_warningIndex]--;
+                if (_warningTiming[_warningIndex] == 0) {
+                    // 警告を表示、その後、銃弾の回転
+                    StartCoroutine(rotateCoroutines[_warningIndex]);
+                    // 次の警告の表示タイミングを監視する
+                    if (_warningIndex != _turnDirection.Length - 1)
+                        _warningIndex++;
+                }
 
-            if (_rotating) {
-                // 回転中
-                transform.Translate(motionVector * _rotatingSpeed, Space.World);
-            } else {
-                // 直進中
-                transform.Translate(motionVector * speed, Space.World);
+                if (_rotating) {
+                    // 回転中
+                    transform.Translate(motionVector * _rotatingSpeed, Space.World);
+                } else {
+                    // 直進中
+                    transform.Translate(motionVector * speed, Space.World);
+                }
             }
         }
 
@@ -150,7 +161,6 @@ namespace Project.Scripts.GamePlayScene.Bullet
                 _warningTiming[index] = (int)Math.Round(_COUNT + (Vector2.Distance(_turnPoint[index - 1], _turnPoint[index]) - (PanelSize.WIDTH - CartridgeSize.WIDTH)) / speed, MidpointRounding.AwayFromZero);
                 rotateCoroutines[index] = DisplayTurnWarning(_turnPoint[index], _turnDirection[index], _turnAngle[index]);
             }
-            _warningTiming[turnDirection.Length] = int.MaxValue;
         }
 
         /// <summary>
@@ -208,7 +218,6 @@ namespace Project.Scripts.GamePlayScene.Bullet
             base.OnFail();
             StopAllCoroutines();
             motionVector = new Vector2(0, 0);
-            _warningTiming[warningIndex] = 0;
         }
     }
 }

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/TurnCartridgeController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/TurnCartridgeController.cs
@@ -22,7 +22,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
         /// <summary>
         /// NormalWarningのPrefab
         /// </summary>
-        public GameObject _normalCartridgeWarningPrefab;
+        [SerializeField] private GameObject _normalCartridgeWarningPrefab;
 
         /// <summary>
         /// 警告を表示するフレームの配列
@@ -74,7 +74,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
         /// 曲がる方向に応じて表示分けする警告画像の名前
         /// </summary>
         /// <value></value>
-        private enum ETurnWarning {
+        private enum _ETurnWarning {
             turnLeft,
             turnRight,
             turnUp,
@@ -99,7 +99,6 @@ namespace Project.Scripts.GamePlayScene.Bullet
                 // 直進中
                 transform.Translate(motionVector * speed, Space.World);
             }
-
         }
 
         /// <summary>
@@ -194,7 +193,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
             _warning.GetComponent<Renderer>().sortingOrder = gameObject.GetComponent<Renderer>().sortingOrder;
             // warningの位置・大きさ等の設定
             var warningScript = _warning.GetComponent<CartridgeWarningController>();
-            warningScript.Initialize(warningPosition, Enum.GetName(typeof(ETurnWarning), turnDirection - 1));
+            warningScript.Initialize(warningPosition, Enum.GetName(typeof(_ETurnWarning), turnDirection - 1));
             // 警告の表示時間だけ待つ
             for (var index = 0; index < _FRAME_RATE; index++) yield return new WaitForFixedUpdate();
             // 警告を削除する

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/TurnCartridgeController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/TurnCartridgeController.cs
@@ -59,7 +59,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
         /// </summary>
         private float _rotatingSpeed =
             ((PanelSize.WIDTH - CartridgeSize.WIDTH) / 2f) * 2f * (float) Math.PI / 4f / _COUNT;
-        
+
         /// <summary>
         /// 銃弾が回転しているかどうかを表す状態
         /// </summary>
@@ -69,7 +69,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
         /// 警告を表示し、銃弾を回転させるcoroutineの配列
         /// </summary>
         private IEnumerator[] rotateCoroutines;
-        
+
         /// <summary>
         /// 曲がる方向に応じて表示分けする警告画像の名前
         /// </summary>
@@ -85,21 +85,17 @@ namespace Project.Scripts.GamePlayScene.Bullet
         {
             // 警告を表示するタイミングかどうかを毎フレーム監視する
             _warningTiming[warningIndex]--;
-            if(_warningTiming[warningIndex] == 0)
-            {
+            if (_warningTiming[warningIndex] == 0) {
                 // 警告を表示、その後、銃弾の回転
                 StartCoroutine(rotateCoroutines[warningIndex]);
                 // 次の警告の表示タイミングを監視する
                 warningIndex++;
             }
 
-            if(_rotating)
-            {
+            if (_rotating) {
                 // 回転中
                 transform.Translate(motionVector * _rotatingSpeed, Space.World);
-            }
-            else
-            {
+            } else {
                 // 直進中
                 transform.Translate(motionVector * speed, Space.World);
             }
@@ -127,34 +123,32 @@ namespace Project.Scripts.GamePlayScene.Bullet
             Vector2 cartridgeMotionVector = motionVector;
             _turnAngle = new float[turnDirection.Length];
             _turnPoint = new Vector2[turnDirection.Length];
-            for(var index=0; index<turnDirection.Length; index++)
-            {
+            for (var index = 0; index < turnDirection.Length; index++) {
                 // 警告の座標
                 _turnPoint[index] = cartridgePosition * cartridgeMotionVector.Transposition().Abs() + new Vector2(
-                    TileSize.WIDTH * (turnLine[index] - 2),
-                    WindowSize.HEIGHT * 0.5f - (TileSize.MARGIN_TOP + TileSize.HEIGHT * 0.5f) -
-                    TileSize.HEIGHT * (turnLine[index] - 1)) * cartridgeMotionVector.Abs();
+                        TileSize.WIDTH * (turnLine[index] - 2),
+                        WindowSize.HEIGHT * 0.5f - (TileSize.MARGIN_TOP + TileSize.HEIGHT * 0.5f) -
+                        TileSize.HEIGHT * (turnLine[index] - 1)) * cartridgeMotionVector.Abs();
                 // 1フレームあたりの回転の角度
                 _turnAngle[index] = _turnDirection[index] % 2 == 1 ? 90 : -90;
                 _turnAngle[index] = (cartridgeMotionVector.x + cartridgeMotionVector.y) * _turnAngle[index];
-                _turnAngle[index] = _turnAngle[index] / (_COUNT-1) / 180.0f * Mathf.PI;
+                _turnAngle[index] = _turnAngle[index] / (_COUNT - 1) / 180.0f * Mathf.PI;
                 // 求めた警告の座標を銃弾の座標として次の警告の座標を求める
                 cartridgePosition = _turnPoint[index];
-                cartridgeMotionVector = cartridgeMotionVector.Rotate(_turnAngle[index] * (_COUNT-1));
+                cartridgeMotionVector = cartridgeMotionVector.Rotate(_turnAngle[index] * (_COUNT - 1));
             }
 
             // 1つ目の警告を表示させるタイミングを求める
             // 警告座標に到達する時間(= 銃弾が進む距離 / 銃弾の速さ)のNフレーム前が表示タイミング
-            _warningTiming = new int[turnDirection.Length+1];
-            _warningTiming[0] = (int)Math.Round((Vector2.Distance(transform.position, _turnPoint[0]) - (PanelSize.WIDTH - CartridgeSize.WIDTH)/2f) / speed - _FRAME_RATE * BulletWarningController.WARNING_DISPLAYED_TIME, MidpointRounding.AwayFromZero);
+            _warningTiming = new int[turnDirection.Length + 1];
+            _warningTiming[0] = (int)Math.Round((Vector2.Distance(transform.position, _turnPoint[0]) - (PanelSize.WIDTH - CartridgeSize.WIDTH) / 2f) / speed - _FRAME_RATE * BulletWarningController.WARNING_DISPLAYED_TIME, MidpointRounding.AwayFromZero);
             // 警告の表示および銃弾が回転する挙動を特定のタイミングで発火できるようにcoroutineにセットする
             rotateCoroutines = new IEnumerator[turnDirection.Length];
             rotateCoroutines[0] = DisplayTurnWarning(_turnPoint[0], _turnDirection[0], _turnAngle[0]);
-            for(var index=1; index<turnDirection.Length; index++)
-            {
+            for (var index = 1; index < turnDirection.Length; index++) {
                 // 1つ前の警告の表示タイミングから何フレーム後に表示させるかを求める
                 // 警告座標に到達する時間(= 1つ前の表示タイミングのNフレーム後 + 銃弾が回転にかかるフレーム数 + (警告と警告との距離) / 銃弾の速さ)のNフレーム前
-                _warningTiming[index] = (int)Math.Round(_COUNT + (Vector2.Distance(_turnPoint[index-1], _turnPoint[index]) - (PanelSize.WIDTH - CartridgeSize.WIDTH))/speed, MidpointRounding.AwayFromZero);
+                _warningTiming[index] = (int)Math.Round(_COUNT + (Vector2.Distance(_turnPoint[index - 1], _turnPoint[index]) - (PanelSize.WIDTH - CartridgeSize.WIDTH)) / speed, MidpointRounding.AwayFromZero);
                 rotateCoroutines[index] = DisplayTurnWarning(_turnPoint[index], _turnDirection[index], _turnAngle[index]);
             }
             _warningTiming[turnDirection.Length] = int.MaxValue;
@@ -173,8 +167,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
             transform.Rotate(new Vector3(0, 0, turnAngle / 2f / Mathf.PI * 180f), Space.World);
             yield return new WaitForFixedUpdate();
             // 回転中のフレーム
-            for (var index = 0; index<_COUNT-2; index++)
-            {
+            for (var index = 0; index < _COUNT - 2; index++) {
                 motionVector = motionVector.Rotate(turnAngle);
                 transform.Rotate(new Vector3(0, 0, turnAngle / Mathf.PI * 180f), Space.World);
                 yield return new WaitForFixedUpdate();
@@ -203,7 +196,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
             var warningScript = _warning.GetComponent<CartridgeWarningController>();
             warningScript.Initialize(warningPosition, Enum.GetName(typeof(ETurnWarning), turnDirection - 1));
             // 警告の表示時間だけ待つ
-            for (var index=0; index<_FRAME_RATE; index++) yield return new WaitForFixedUpdate();
+            for (var index = 0; index < _FRAME_RATE; index++) yield return new WaitForFixedUpdate();
             // 警告を削除する
             Destroy(_warning);
             // 銃弾を回転させる
@@ -215,7 +208,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
         {
             base.OnFail();
             StopAllCoroutines();
-            motionVector = new Vector2(0,0);
+            motionVector = new Vector2(0, 0);
             _warningTiming[warningIndex] = 0;
         }
     }

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/TurnCartridgeController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/TurnCartridgeController.cs
@@ -57,6 +57,11 @@ namespace Project.Scripts.GamePlayScene.Bullet
         private const float _FRAME_RATE = 50;
 
         /// <summary>
+        /// 警告表示後から銃弾が警告座標に到達するフレーム数
+        /// </summary>
+        private const int _RUNNING_FRAME = 30;
+
+        /// <summary>
         /// 回転中の銃弾の速さ (円周(= 回転半径 * 2 * pi)の4分の1をフレーム数で割る)
         /// </summary>
         private float _rotatingSpeed =
@@ -150,8 +155,8 @@ namespace Project.Scripts.GamePlayScene.Bullet
 
             // 1つ目の警告を表示させるタイミングを求める
             // 警告座標に到達する時間(= 銃弾が進む距離 / 銃弾の速さ)のNフレーム前が表示タイミング
-            _warningTiming = new int[turnDirection.Length + 1];
-            _warningTiming[0] = (int)Math.Round((Vector2.Distance(transform.position, _turnPoint[0]) - (PanelSize.WIDTH - CartridgeSize.WIDTH) / 2f) / speed - _FRAME_RATE * BulletWarningController.WARNING_DISPLAYED_TIME, MidpointRounding.AwayFromZero);
+            _warningTiming = new int[turnDirection.Length];
+            _warningTiming[0] = (int)Math.Round((Vector2.Distance(transform.position, _turnPoint[0]) - (PanelSize.WIDTH - CartridgeSize.WIDTH) / 2f) / speed - _FRAME_RATE * BulletWarningController.WARNING_DISPLAYED_TIME - _RUNNING_FRAME, MidpointRounding.AwayFromZero);
             // 警告の表示および銃弾が回転する挙動を特定のタイミングで発火できるようにcoroutineにセットする
             rotateCoroutines = new IEnumerator[turnDirection.Length];
             rotateCoroutines[0] = DisplayTurnWarning(_turnPoint[0], _turnDirection[0], _turnAngle[0]);
@@ -208,6 +213,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
             for (var index = 0; index < _FRAME_RATE; index++) yield return new WaitForFixedUpdate();
             // 警告を削除する
             Destroy(_warning);
+            for (var index = 0; index < _RUNNING_FRAME; index++) yield return new WaitForFixedUpdate();
             // 銃弾を回転させる
             StartCoroutine(RotateCartridge(turnAngle));
             yield break;

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/TurnCartridgeController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/TurnCartridgeController.cs
@@ -1,9 +1,9 @@
-﻿using UnityEngine;
-using System;
-using System.Linq;
+﻿using System;
+using System.Collections;
 using Project.Scripts.GamePlayScene.BulletWarning;
 using Project.Scripts.Utils.Definitions;
 using Project.Scripts.Utils.Library.Extension;
+using UnityEngine;
 
 namespace Project.Scripts.GamePlayScene.Bullet
 {
@@ -20,12 +20,58 @@ namespace Project.Scripts.GamePlayScene.Bullet
         private int[] _turnLine;
 
         /// <summary>
-        /// 曲がる方向を示す警告の座標
+        /// NormalWarningのPrefab
         /// </summary>
-        private Vector2 _turnPoint;
+        public GameObject _normalCartridgeWarningPrefab;
 
         /// <summary>
-        /// 曲がる方向に応じて表示わけする警告画像の名前
+        /// 警告を表示するフレームの配列
+        /// </summary>
+        private int[] _warningTiming;
+
+        /// <summary>
+        /// 次に表示する警告のインデックス
+        /// </summary>
+        private int warningIndex = 0;
+
+        /// <summary>
+        /// 曲がる方向を示す警告の座標の配列
+        /// </summary>
+        private Vector2[] _turnPoint;
+
+        /// <summary>
+        /// 1フレームあたりの回転角度
+        /// </summary>
+        private float[] _turnAngle;
+
+        /// <summary>
+        /// 回転に要するフレーム数
+        /// </summary>
+        private const int _COUNT = 50;
+
+        /// <summary>
+        /// Unity GUIで設定したfps
+        /// </summary>
+        private const float _FRAME_RATE = 50;
+
+        /// <summary>
+        /// 回転中の銃弾の速さ (円周(= 回転半径 * 2 * pi)の4分の1をフレーム数で割る)
+        /// </summary>
+        private float _rotatingSpeed =
+            ((PanelSize.WIDTH - CartridgeSize.WIDTH) / 2f) * 2f * (float) Math.PI / 4f / _COUNT;
+        
+        /// <summary>
+        /// 銃弾が回転しているかどうかを表す状態
+        /// </summary>
+        private bool _rotating = false;
+
+        /// <summary>
+        /// 警告を表示し、銃弾を回転させるcoroutineの配列
+        /// </summary>
+        private IEnumerator[] rotateCoroutines;
+        
+        /// <summary>
+        /// 曲がる方向に応じて表示分けする警告画像の名前
         /// </summary>
         /// <value></value>
         private enum ETurnWarning {
@@ -35,100 +81,34 @@ namespace Project.Scripts.GamePlayScene.Bullet
             turnBottom
         }
 
-        /// <summary>
-        /// NormalWarningのPrefab
-        /// </summary>
-        public GameObject _normalCartridgeWarningPrefab;
-        /// <summary>
-        /// NormalWarning
-        /// </summary>
-        private GameObject _warning;
-
-        /// <summary>
-        /// 1フレームあたりの回転角度
-        /// </summary>
-        private float _turnAngle;
-
-        /// <summary>
-        /// 回転に要するフレーム数
-        /// </summary>
-        private const int COUNT = 50;
-
-        /// <summary>
-        /// 回転の何フレーム目か
-        /// </summary>
-        private int _rotateCount = -1;
-
-        /// <summary>
-        /// 回転中の銃弾の速さ (円周(=回転半径 * 2 * pi)の4分の1をフレーム数で割る)
-        /// </summary>
-        private float rotatingSpeed =
-            ((PanelSize.WIDTH - CartridgeSize.WIDTH) / 2f) * 2f * (float) Math.PI / 4f / COUNT;
-
         protected override void FixedUpdate()
         {
-            // 回転する座標に近づいたら警告を表示する
-            if (_rotateCount == -1 && Vector2.Distance(_turnPoint, transform.position) <=
-                (PanelSize.WIDTH - CartridgeSize.WIDTH) / 2f + speed * 50) {
-                _warning = Instantiate(_normalCartridgeWarningPrefab);
-                // 同レイヤーのオブジェクトの描画順序の制御
-                _warning.GetComponent<Renderer>().sortingOrder = gameObject.GetComponent<Renderer>().sortingOrder;
-                // warningの位置・大きさ等の設定
-                var warningScript = _warning.GetComponent<CartridgeWarningController>();
-                warningScript.Initialize(_turnPoint, Enum.GetName(typeof(ETurnWarning), _turnDirection[0] - 1));
-                _rotateCount++;
-                transform.Translate(motionVector * speed, Space.World);
+            // 警告を表示するタイミングかどうかを毎フレーム監視する
+            _warningTiming[warningIndex]--;
+            if(_warningTiming[warningIndex] == 0)
+            {
+                // 警告を表示、その後、銃弾の回転
+                StartCoroutine(rotateCoroutines[warningIndex]);
+                // 次の警告の表示タイミングを監視する
+                warningIndex++;
             }
-            // 回転はじめのフレーム
-            else if (_rotateCount == 0 && Vector2.Distance(_turnPoint, transform.position) <=
-                (PanelSize.WIDTH - CartridgeSize.WIDTH) / 2f) {
-                Destroy(_warning);
-                _rotateCount++;
-                motionVector = motionVector.Rotate(_turnAngle / 2f);
-                transform.Rotate(new Vector3(0, 0, _turnAngle / 2f / Mathf.PI * 180f), Space.World);
-                transform.Translate(motionVector * rotatingSpeed, Space.World);
-            }
-            // 回転中のフレーム
-            else if (0 < _rotateCount && _rotateCount <= COUNT - 1) {
-                _rotateCount++;
-                motionVector = motionVector.Rotate(_turnAngle);
-                transform.Rotate(new Vector3(0, 0, _turnAngle / Mathf.PI * 180f), Space.World);
-                transform.Translate(motionVector * rotatingSpeed, Space.World);
-            }
-            // 回転おわりのフレーム
-            else if (_rotateCount == COUNT) {
-                transform.Rotate(new Vector3(0, 0, _turnAngle / 2f / Mathf.PI * 180f), Space.World);
-                motionVector = motionVector.Rotate(_turnAngle / 2f);
 
-                // 別のタイル上でまだ回転する場合
-                if (_turnDirection.Length >= 2) {
-                    // 配列の先頭要素を除く部分配列を取得する
-                    _turnDirection = _turnDirection.Skip(1).Take(_turnDirection.Length - 1).ToArray();
-                    _turnLine = _turnLine.Skip(1).Take(_turnLine.Length - 1).ToArray();
-                    _turnPoint = transform.position * motionVector.Transposition().Abs() + new Vector2(
-                            TileSize.WIDTH * (_turnLine[0] - 2),
-                            WindowSize.HEIGHT * 0.5f - (TileSize.MARGIN_TOP + TileSize.HEIGHT * 0.5f) -
-                            TileSize.HEIGHT * (_turnLine[0] - 1)) * motionVector.Abs();
-                    _turnAngle = _turnDirection[0] % 2 == 1 ? 90 : -90;
-                    _turnAngle = (motionVector.x + motionVector.y) * _turnAngle;
-                    _turnAngle = _turnAngle / COUNT / 180.0f * Mathf.PI;
-                    _rotateCount = -1;
-                }
-                // 回転しない場合
-                else {
-                    _rotateCount = -2;
-                }
+            if(_rotating)
+            {
+                // 回転中
+                transform.Translate(motionVector * _rotatingSpeed, Space.World);
+            }
+            else
+            {
+                // 直進中
+                transform.Translate(motionVector * speed, Space.World);
+            }
 
-                transform.Translate(motionVector * speed, Space.World);
-            }
-            // 回転中以外
-            else {
-                transform.Translate(motionVector * speed, Space.World);
-            }
         }
 
         /// <summary>
         /// 銃弾の移動ベクトル、曲がる方向、曲がる行(または列)、初期座標を設定する
+        /// 警告を表示するフレームを計算する
         /// </summary>
         /// <param name="direction"> 移動方向 </param>
         /// <param name="line"> 移動する行(または列) </param>
@@ -142,22 +122,101 @@ namespace Project.Scripts.GamePlayScene.Bullet
             Initialize(direction, line, motionVector);
             this._turnDirection = turnDirection;
             this._turnLine = turnLine;
-            // 銃弾が曲がるタイルの座標
-            _turnPoint = transform.position * motionVector.Transposition().Abs() + new Vector2(
-                    TileSize.WIDTH * (turnLine[0] - 2),
+            // 表示する全ての警告の座標および回転の角度を計算
+            Vector2 cartridgePosition = transform.position;
+            Vector2 cartridgeMotionVector = motionVector;
+            _turnAngle = new float[turnDirection.Length];
+            _turnPoint = new Vector2[turnDirection.Length];
+            for(var index=0; index<turnDirection.Length; index++)
+            {
+                // 警告の座標
+                _turnPoint[index] = cartridgePosition * cartridgeMotionVector.Transposition().Abs() + new Vector2(
+                    TileSize.WIDTH * (turnLine[index] - 2),
                     WindowSize.HEIGHT * 0.5f - (TileSize.MARGIN_TOP + TileSize.HEIGHT * 0.5f) -
-                    TileSize.HEIGHT * (turnLine[0] - 1)) * motionVector.Abs();
-            // 回転角度
-            _turnAngle = turnDirection[0] % 2 == 1 ? 90 : -90;
-            _turnAngle = (motionVector.x + motionVector.y) * _turnAngle;
-            _turnAngle = _turnAngle / COUNT / 180.0f * Mathf.PI;
+                    TileSize.HEIGHT * (turnLine[index] - 1)) * cartridgeMotionVector.Abs();
+                // 1フレームあたりの回転の角度
+                _turnAngle[index] = _turnDirection[index] % 2 == 1 ? 90 : -90;
+                _turnAngle[index] = (cartridgeMotionVector.x + cartridgeMotionVector.y) * _turnAngle[index];
+                _turnAngle[index] = _turnAngle[index] / (_COUNT-1) / 180.0f * Mathf.PI;
+                // 求めた警告の座標を銃弾の座標として次の警告の座標を求める
+                cartridgePosition = _turnPoint[index];
+                cartridgeMotionVector = cartridgeMotionVector.Rotate(_turnAngle[index] * (_COUNT-1));
+            }
+
+            // 1つ目の警告を表示させるタイミングを求める
+            // 警告座標に到達する時間(= 銃弾が進む距離 / 銃弾の速さ)のNフレーム前が表示タイミング
+            _warningTiming = new int[turnDirection.Length+1];
+            _warningTiming[0] = (int)Math.Round((Vector2.Distance(transform.position, _turnPoint[0]) - (PanelSize.WIDTH - CartridgeSize.WIDTH)/2f) / speed - _FRAME_RATE * BulletWarningController.WARNING_DISPLAYED_TIME, MidpointRounding.AwayFromZero);
+            // 警告の表示および銃弾が回転する挙動を特定のタイミングで発火できるようにcoroutineにセットする
+            rotateCoroutines = new IEnumerator[turnDirection.Length];
+            rotateCoroutines[0] = DisplayTurnWarning(_turnPoint[0], _turnDirection[0], _turnAngle[0]);
+            for(var index=1; index<turnDirection.Length; index++)
+            {
+                // 1つ前の警告の表示タイミングから何フレーム後に表示させるかを求める
+                // 警告座標に到達する時間(= 1つ前の表示タイミングのNフレーム後 + 銃弾が回転にかかるフレーム数 + (警告と警告との距離) / 銃弾の速さ)のNフレーム前
+                _warningTiming[index] = (int)Math.Round(_COUNT + (Vector2.Distance(_turnPoint[index-1], _turnPoint[index]) - (PanelSize.WIDTH - CartridgeSize.WIDTH))/speed, MidpointRounding.AwayFromZero);
+                rotateCoroutines[index] = DisplayTurnWarning(_turnPoint[index], _turnDirection[index], _turnAngle[index]);
+            }
+            _warningTiming[turnDirection.Length] = int.MaxValue;
+        }
+
+        /// <summary>
+        /// 銃弾を回転させるcoroutine
+        /// </summary>
+        /// <param name="turnAngle"> 1フレームあたりの回転角 </param>
+        /// <returns></returns>
+        private IEnumerator RotateCartridge(float turnAngle)
+        {
+            _rotating = true;
+            // 回転はじめのフレーム
+            motionVector = motionVector.Rotate(turnAngle / 2f);
+            transform.Rotate(new Vector3(0, 0, turnAngle / 2f / Mathf.PI * 180f), Space.World);
+            yield return new WaitForFixedUpdate();
+            // 回転中のフレーム
+            for (var index = 0; index<_COUNT-2; index++)
+            {
+                motionVector = motionVector.Rotate(turnAngle);
+                transform.Rotate(new Vector3(0, 0, turnAngle / Mathf.PI * 180f), Space.World);
+                yield return new WaitForFixedUpdate();
+            }
+            // 回転終わりのフレーム
+            motionVector = motionVector.Rotate(turnAngle / 2f);
+            transform.Rotate(new Vector3(0, 0, turnAngle / 2f / Mathf.PI * 180f), Space.World);
+            yield return new WaitForFixedUpdate();
+            _rotating = false;
+            yield break;
+        }
+
+        /// <summary>
+        /// 警告を表示するcoroutine
+        /// </summary>
+        /// <param name="warningPosition"> 警告の座標 </param>
+        /// <param name="turnDirection"> 回転の方向 </param>
+        /// <param name="turnAngle"> 1フレームあたりの回転角 </param>
+        /// <returns></returns>
+        private IEnumerator DisplayTurnWarning(Vector2 warningPosition, int turnDirection, float turnAngle)
+        {
+            var _warning = Instantiate(_normalCartridgeWarningPrefab);
+            // 同レイヤーのオブジェクトの描画順序の制御
+            _warning.GetComponent<Renderer>().sortingOrder = gameObject.GetComponent<Renderer>().sortingOrder;
+            // warningの位置・大きさ等の設定
+            var warningScript = _warning.GetComponent<CartridgeWarningController>();
+            warningScript.Initialize(warningPosition, Enum.GetName(typeof(ETurnWarning), turnDirection - 1));
+            // 警告の表示時間だけ待つ
+            for (var index=0; index<_FRAME_RATE; index++) yield return new WaitForFixedUpdate();
+            // 警告を削除する
+            Destroy(_warning);
+            // 銃弾を回転させる
+            StartCoroutine(RotateCartridge(turnAngle));
+            yield break;
         }
 
         protected override void OnFail()
         {
             base.OnFail();
-            rotatingSpeed = 0;
-            _turnAngle = 0;
+            StopAllCoroutines();
+            motionVector = new Vector2(0,0);
+            _warningTiming[warningIndex] = 0;
         }
     }
 }

--- a/Assets/Project/Scripts/GamePlayScene/StageGenerator.cs
+++ b/Assets/Project/Scripts/GamePlayScene/StageGenerator.cs
@@ -84,8 +84,8 @@ namespace Project.Scripts.GamePlayScene
                     bulletGenerators: new List<GameObject>() {
                         bulletGroupGenerator.CreateTurnCartridgeGenerator(ratio: 100,
                             cartridgeDirection: ECartridgeDirection.ToLeft, row: ERow.First,
-                            turnDirection: new int[] {(int) ECartridgeDirection.ToBottom},
-                            turnLine: new int[] {(int) EColumn.Left})
+                            turnDirection: new int[] {(int) ECartridgeDirection.ToBottom, (int) ECartridgeDirection.ToRight, (int) ECartridgeDirection.ToUp, (int) ECartridgeDirection.ToLeft},
+                            turnLine: new int[] {(int) EColumn.Left, (int) ERow.Second, (int) EColumn.Right, (int) ERow.First})
                     }));
                     /* 特殊タイル -> 数字パネル -> 特殊パネル */
                     // 特殊タイル作成
@@ -93,14 +93,14 @@ namespace Project.Scripts.GamePlayScene
                     // 数字パネル作成
                     panelGenerator.PrepareTilesAndCreateNumberPanels(
                     new List<Dictionary<string, int>>() {
-                        PanelGenerator.ComvartToDictionary(panelNum: 1, initialTileNum: 1, finalTileNum: 4),
-                                                           PanelGenerator.ComvartToDictionary(panelNum: 2, initialTileNum: 3, finalTileNum: 5),
-                                                           PanelGenerator.ComvartToDictionary(panelNum: 3, initialTileNum: 5, finalTileNum: 6),
-                                                           PanelGenerator.ComvartToDictionary(panelNum: 4, initialTileNum: 6, finalTileNum: 7),
-                                                           PanelGenerator.ComvartToDictionary(panelNum: 5, initialTileNum: 8, finalTileNum: 8),
-                                                           PanelGenerator.ComvartToDictionary(panelNum: 6, initialTileNum: 11, finalTileNum: 9),
+                        PanelGenerator.ComvartToDictionary(panelNum: 1, initialTileNum: 7, finalTileNum: 4),
+                                                           PanelGenerator.ComvartToDictionary(panelNum: 2, initialTileNum: 8, finalTileNum: 5),
+                                                           PanelGenerator.ComvartToDictionary(panelNum: 3, initialTileNum: 9, finalTileNum: 6),
+                                                           PanelGenerator.ComvartToDictionary(panelNum: 4, initialTileNum: 10, finalTileNum: 7),
+                                                           PanelGenerator.ComvartToDictionary(panelNum: 5, initialTileNum: 11, finalTileNum: 8),
+                                                           PanelGenerator.ComvartToDictionary(panelNum: 6, initialTileNum: 12, finalTileNum: 9),
                                                            PanelGenerator.ComvartToDictionary(panelNum: 7, initialTileNum: 13, finalTileNum: 10),
-                                                           PanelGenerator.ComvartToDictionary(panelNum: 8, initialTileNum: 15, finalTileNum: 11)
+                                                           PanelGenerator.ComvartToDictionary(panelNum: 8, initialTileNum: 14, finalTileNum: 11)
                     }
                     );
                     break;


### PR DESCRIPTION
## 対象イシュー
Close #74


## 概要
曲がる銃弾の警告の表示タイミングの修正
N回曲がる銃弾を作成するとき、K(K>1)回目の警告画像は(K-1)回目の銃弾回転後に表示していたので、隣のタイルで連続して回転するときは、K回目の警告の表示時間が極端に短かった。
ステージID:3をプレイしてください。
## 技術的な内容
- 銃弾生成時に、N個の警告の表示場所、表示タイミングを求める。毎フレーム表示タイミングかどうかを調べる。
- _warningTIme[]に{50, 10, 5, 12}のように入っている場合、銃弾出現時刻から`50`フレーム、`60(=50+10)`フレーム、`65(=60+5)`フレーム、`77(=65+12)`フレームの時に警告が表示されます。
- 銃弾の表示時間`WARNING_DISPLAYED_TIME=1.0f(秒)`はUnityで設定したFPSだと`50`フレームなんだけど、スクリプトで明示的にそれを取得・関連づけられてない。
ので、`TurnCartridgeController.cs`で`_FRAME_RATE=50`と定義している。（できれば直したいところ。。。）

## キャプチャ
