### PR TITLE
警告画像の表示時間を秒ではなくフレームで管理する

### DIFF
--- a/Assets/Project/Scripts/GamePlayScene/Bullet/AimingHoleGenerator.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/AimingHoleGenerator.cs
@@ -67,7 +67,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
             var warningScript = warning.GetComponent<AimingHoleWarningController>();
             warningScript.Initialize(nextAimingPanel, ref _aimingHoleCount);
             // 警告の表示時間だけ待つ
-            for(int index=0; index<BulletWarningParameter.WARNING_DISPLAYED_FRAMES; index++) yield return new WaitForFixedUpdate();
+            for (int index = 0; index < BulletWarningParameter.WARNING_DISPLAYED_FRAMES; index++) yield return new WaitForFixedUpdate();
             // 警告を削除する
             Destroy(warning);
 

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/AimingHoleGenerator.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/AimingHoleGenerator.cs
@@ -67,7 +67,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
             var warningScript = warning.GetComponent<AimingHoleWarningController>();
             warningScript.Initialize(nextAimingPanel, ref _aimingHoleCount);
             // 警告の表示時間だけ待つ
-            yield return new WaitForSeconds(BulletWarningController.WARNING_DISPLAYED_TIME);
+            for(int index=0; index<BulletWarningParameter.WARNING_DISPLAYED_FRAMES; index++) yield return new WaitForFixedUpdate();
             // 警告を削除する
             Destroy(warning);
 

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/BulletGroupController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/BulletGroupController.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using Project.Scripts.GamePlayScene.BulletWarning;
+using Project.Scripts.Utils.Definitions;
 using Project.Scripts.Utils.Library;
 
 namespace Project.Scripts.GamePlayScene.Bullet
@@ -93,7 +93,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
         public IEnumerator CreateBullets()
         {
             var currentTime = Time.time;
-            yield return new WaitForSeconds(_appearanceTime - BulletWarningController.WARNING_DISPLAYED_TIME -
+            yield return new WaitForSeconds(_appearanceTime - BulletWarningParameter.WARNING_DISPLAYED_TIME -
                     (currentTime - _bulletGroupGenerator.startTime));
             var sum = 0;
 
@@ -115,7 +115,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
 
                 // 次の銃弾を作成する時刻まで待つ
                 currentTime = Time.time;
-                yield return new WaitForSeconds(_appearanceTime - BulletWarningController.WARNING_DISPLAYED_TIME +
+                yield return new WaitForSeconds(_appearanceTime - BulletWarningParameter.WARNING_DISPLAYED_TIME +
                         _interval * sum - (currentTime - _bulletGroupGenerator.startTime));
             } while (_loop);
         }

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/NormalCartridgeGenerator.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/NormalCartridgeGenerator.cs
@@ -120,7 +120,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
                 warningScript.Initialize(ECartridgeType.Normal, nextCartridgeDirection, nextCartridgeLine);
 
             // 警告の表示時間だけ待つ
-            yield return new WaitForSeconds(BulletWarningController.WARNING_DISPLAYED_TIME);
+            for(int index=0; index<BulletWarningParameter.WARNING_DISPLAYED_FRAMES; index++) yield return new WaitForFixedUpdate();
             // 警告を削除する
             Destroy(warning);
 

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/NormalCartridgeGenerator.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/NormalCartridgeGenerator.cs
@@ -120,7 +120,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
                 warningScript.Initialize(ECartridgeType.Normal, nextCartridgeDirection, nextCartridgeLine);
 
             // 警告の表示時間だけ待つ
-            for(int index=0; index<BulletWarningParameter.WARNING_DISPLAYED_FRAMES; index++) yield return new WaitForFixedUpdate();
+            for (int index = 0; index < BulletWarningParameter.WARNING_DISPLAYED_FRAMES; index++) yield return new WaitForFixedUpdate();
             // 警告を削除する
             Destroy(warning);
 

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/NormalHoleGenerator.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/NormalHoleGenerator.cs
@@ -78,7 +78,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
             var warningScript = warning.GetComponent<NormalHoleWarningController>();
             warningScript.Initialize(nextHoleRow, nextHoleColumn);
             // 警告の表示時間だけ待つ
-            for(int index=0; index<BulletWarningParameter.WARNING_DISPLAYED_FRAMES; index++) yield return new WaitForFixedUpdate();
+            for (int index = 0; index < BulletWarningParameter.WARNING_DISPLAYED_FRAMES; index++) yield return new WaitForFixedUpdate();
             // 警告を削除する
             Destroy(warning);
 

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/NormalHoleGenerator.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/NormalHoleGenerator.cs
@@ -78,7 +78,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
             var warningScript = warning.GetComponent<NormalHoleWarningController>();
             warningScript.Initialize(nextHoleRow, nextHoleColumn);
             // 警告の表示時間だけ待つ
-            yield return new WaitForSeconds(BulletWarningController.WARNING_DISPLAYED_TIME);
+            for(int index=0; index<BulletWarningParameter.WARNING_DISPLAYED_FRAMES; index++) yield return new WaitForFixedUpdate();
             // 警告を削除する
             Destroy(warning);
 

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/TurnCartridgeController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/TurnCartridgeController.cs
@@ -52,11 +52,6 @@ namespace Project.Scripts.GamePlayScene.Bullet
         private const int _COUNT = 50;
 
         /// <summary>
-        /// Unity GUIで設定したfps
-        /// </summary>
-        private const float _FRAME_RATE = 50;
-
-        /// <summary>
         /// 警告表示後から銃弾が警告座標に到達するフレーム数
         /// </summary>
         private const int _RUNNING_FRAME = 30;
@@ -156,7 +151,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
             // 1つ目の警告を表示させるタイミングを求める
             // 警告座標に到達する時間(= 銃弾が進む距離 / 銃弾の速さ)のNフレーム前が表示タイミング
             _warningTiming = new int[turnDirection.Length];
-            _warningTiming[0] = (int)Math.Round((Vector2.Distance(transform.position, _turnPoint[0]) - (PanelSize.WIDTH - CartridgeSize.WIDTH) / 2f) / speed - _FRAME_RATE * BulletWarningController.WARNING_DISPLAYED_TIME - _RUNNING_FRAME, MidpointRounding.AwayFromZero);
+            _warningTiming[0] = (int)Math.Round((Vector2.Distance(transform.position, _turnPoint[0]) - (PanelSize.WIDTH - CartridgeSize.WIDTH) / 2f) / speed - BulletWarningParameter.WARNING_DISPLAYED_FRAMES - _RUNNING_FRAME, MidpointRounding.AwayFromZero);
             // 警告の表示および銃弾が回転する挙動を特定のタイミングで発火できるようにcoroutineにセットする
             rotateCoroutines = new IEnumerator[turnDirection.Length];
             rotateCoroutines[0] = DisplayTurnWarning(_turnPoint[0], _turnDirection[0], _turnAngle[0]);
@@ -210,7 +205,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
             var warningScript = _warning.GetComponent<CartridgeWarningController>();
             warningScript.Initialize(warningPosition, Enum.GetName(typeof(_ETurnWarning), turnDirection - 1));
             // 警告の表示時間だけ待つ
-            for (var index = 0; index < _FRAME_RATE; index++) yield return new WaitForFixedUpdate();
+            for (var index = 0; index < BulletWarningParameter.WARNING_DISPLAYED_FRAMES; index++) yield return new WaitForFixedUpdate();
             // 警告を削除する
             Destroy(_warning);
             for (var index = 0; index < _RUNNING_FRAME; index++) yield return new WaitForFixedUpdate();

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/TurnCartridgeGenerator.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/TurnCartridgeGenerator.cs
@@ -133,7 +133,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
                 warningScript.Initialize(ECartridgeType.Turn, nextCartridgeDirection, nextCartridgeLine);
 
             // 警告の表示時間だけ待つ
-            yield return new WaitForSeconds(BulletWarningController.WARNING_DISPLAYED_TIME);
+            for(int index=0; index<BulletWarningParameter.WARNING_DISPLAYED_FRAMES; index++) yield return new WaitForFixedUpdate();
             // 警告を削除する
             Destroy(warning);
 

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/TurnCartridgeGenerator.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/TurnCartridgeGenerator.cs
@@ -133,7 +133,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
                 warningScript.Initialize(ECartridgeType.Turn, nextCartridgeDirection, nextCartridgeLine);
 
             // 警告の表示時間だけ待つ
-            for(int index=0; index<BulletWarningParameter.WARNING_DISPLAYED_FRAMES; index++) yield return new WaitForFixedUpdate();
+            for (int index = 0; index < BulletWarningParameter.WARNING_DISPLAYED_FRAMES; index++) yield return new WaitForFixedUpdate();
             // 警告を削除する
             Destroy(warning);
 

--- a/Assets/Project/Scripts/GamePlayScene/BulletWarning/BulletWarningController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/BulletWarning/BulletWarningController.cs
@@ -6,11 +6,6 @@ namespace Project.Scripts.GamePlayScene.BulletWarning
     public abstract class BulletWarningController : MonoBehaviour
     {
         /// <summary>
-        /// 表示時間
-        /// </summary>
-        public const float WARNING_DISPLAYED_TIME = 1.0f;
-
-        /// <summary>
         /// 元画像の縦幅
         /// </summary>
         protected float originalHeight;

--- a/Assets/Project/Scripts/Utils/Definitions/BulletWarningDefinitions.cs
+++ b/Assets/Project/Scripts/Utils/Definitions/BulletWarningDefinitions.cs
@@ -13,6 +13,6 @@ namespace Project.Scripts.Utils.Definitions
         ///  警告を表示するフレーム数
         /// </summary>
         /// <returns></returns>
-        public static int WARNING_DISPLAYED_FRAMES = (int) (1.0f / Time.fixedDeltaTime * WARNING_DISPLAYED_TIME);
+        public static int WARNING_DISPLAYED_FRAMES = (int)(1.0f / Time.fixedDeltaTime * WARNING_DISPLAYED_TIME);
     }
 }

--- a/Assets/Project/Scripts/Utils/Definitions/BulletWarningDefinitions.cs
+++ b/Assets/Project/Scripts/Utils/Definitions/BulletWarningDefinitions.cs
@@ -1,0 +1,18 @@
+﻿using UnityEngine;
+
+namespace Project.Scripts.Utils.Definitions
+{
+    public static class BulletWarningParameter
+    {
+        /// <summary>
+        /// 警告を表示する秒数
+        /// </summary>
+        public const float WARNING_DISPLAYED_TIME = 1.0f;
+        　
+        /// <summary>
+        ///  警告を表示するフレーム数
+        /// </summary>
+        /// <returns></returns>
+        public static int WARNING_DISPLAYED_FRAMES = (int) (1.0f / Time.fixedDeltaTime * WARNING_DISPLAYED_TIME);
+    }
+}

--- a/Assets/Project/Scripts/Utils/Definitions/BulletWarningDefinitions.cs.meta
+++ b/Assets/Project/Scripts/Utils/Definitions/BulletWarningDefinitions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 86169b5f41c3e43448822ceadeb08964
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## 対象イシュー
Close #76 

## 概要
元々のイシュー内容は、警告画像の表示時間を処理時間に応じて変更するでした。
- 表示するタイミングは、意図した時間に表示できるように処理時間に応じて調整されていました。
- 表示する長さについては、意図した長さを表示するように調整しました。(←この調整だけのイシュー)

## 技術的な内容
警告の表示時間を秒数で管理するのではなく、`FixedUpdate`の呼ばれる回数で管理するように変更しました。
秒数管理だと、重い処理によってメインスレッドが占有されている時に、意図した長さより長くなったり、常に0.01f(秒)くらいの誤差があり得る(と思う)。
体感では全然違いを感じないけど、警告の表示時間の誤差はゲームの難易度に関わるので改善しました。
`FixedUpdate`は、相当重い処理をかけない限り、1秒間に呼ばれる回数、呼ばれる間隔が決まっているので、信頼できると思います。

## キャプチャ

