### PR TITLE
撃ち抜く銃弾をBoxCollider2Dを用いた実装に変更する

### DIFF
--- a/Assets/Project/Prefabs/GamePlayScene/Bullet/Cartridge/NormalCartridgePrefab.prefab
+++ b/Assets/Project/Prefabs/GamePlayScene/Bullet/Cartridge/NormalCartridgePrefab.prefab
@@ -1,28 +1,20 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1001 &100100000
-Prefab:
-  m_ObjectHideFlags: 1
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications: []
-    m_RemovedComponents: []
-  m_ParentPrefab: {fileID: 0}
-  m_RootGameObject: {fileID: 1336118223516990}
-  m_IsPrefabParent: 1
 --- !u!1 &1336118223516990
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 5
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 4363906504938260}
   - component: {fileID: 212451907916449790}
   - component: {fileID: 114617676760384634}
+  - component: {fileID: 8667623524509177951}
+  - component: {fileID: 5685266870691338383}
   m_Layer: 0
-  m_Name: normalCartridgePrefab
+  m_Name: NormalCartridgePrefab
   m_TagString: Bullet
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -30,9 +22,10 @@ GameObject:
   m_IsActive: 1
 --- !u!4 &4363906504938260
 Transform:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1336118223516990}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -41,26 +34,12 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &114617676760384634
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1336118223516990}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3774f8febe87f444c8912a134322f0fc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  originalWidth: 0
-  originalHeight: 0
-  additionalMargin: 0.00001
-  motionVector: {x: 0, y: 0}
 --- !u!212 &212451907916449790
 SpriteRenderer:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1336118223516990}
   m_Enabled: 1
   m_CastShadows: 0
@@ -70,6 +49,7 @@ SpriteRenderer:
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
   m_RenderingLayerMask: 4294967295
+  m_RendererPriority: 0
   m_Materials:
   - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
   m_StaticBatchInfo:
@@ -101,3 +81,64 @@ SpriteRenderer:
   m_SpriteTileMode: 0
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!114 &114617676760384634
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1336118223516990}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3774f8febe87f444c8912a134322f0fc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  speed: 0.05
+--- !u!61 &8667623524509177951
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1336118223516990}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1.5, y: 0.5}
+    newSize: {x: 1.5, y: 0.5}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1.5, y: 0.5}
+  m_EdgeRadius: 0
+--- !u!50 &5685266870691338383
+Rigidbody2D:
+  serializedVersion: 4
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1336118223516990}
+  m_BodyType: 0
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDrag: 0
+  m_AngularDrag: 0.05
+  m_GravityScale: 1
+  m_Material: {fileID: 0}
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 0

--- a/Assets/Project/Prefabs/GamePlayScene/Bullet/Cartridge/TurnCartridgePrefab.prefab
+++ b/Assets/Project/Prefabs/GamePlayScene/Bullet/Cartridge/TurnCartridgePrefab.prefab
@@ -11,6 +11,8 @@ GameObject:
   - component: {fileID: 4148607833888286}
   - component: {fileID: 212145730030468188}
   - component: {fileID: 114569484378481306}
+  - component: {fileID: -1925789541212344210}
+  - component: {fileID: 1937630506875268259}
   m_Layer: 0
   m_Name: TurnCartridgePrefab
   m_TagString: Bullet
@@ -95,3 +97,50 @@ MonoBehaviour:
   speed: 0.05
   _normalCartridgeWarningPrefab: {fileID: 1368177469308104, guid: a0a9ef946321e42c5b13cf5e58916734,
     type: 3}
+--- !u!61 &-1925789541212344210
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1834930760170460}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1.5, y: 0.5}
+    newSize: {x: 1.5, y: 0.5}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1.5, y: 0.5}
+  m_EdgeRadius: 0
+--- !u!50 &1937630506875268259
+Rigidbody2D:
+  serializedVersion: 4
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1834930760170460}
+  m_BodyType: 0
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDrag: 0
+  m_AngularDrag: 0.05
+  m_GravityScale: 1
+  m_Material: {fileID: 0}
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 0

--- a/Assets/Project/Prefabs/GamePlayScene/Bullet/Hole/NormalHolePrefab.prefab
+++ b/Assets/Project/Prefabs/GamePlayScene/Bullet/Hole/NormalHolePrefab.prefab
@@ -1,28 +1,20 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1001 &100100000
-Prefab:
-  m_ObjectHideFlags: 1
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications: []
-    m_RemovedComponents: []
-  m_ParentPrefab: {fileID: 0}
-  m_RootGameObject: {fileID: 1590802889344152}
-  m_IsPrefabParent: 1
 --- !u!1 &1590802889344152
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 5
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 4949918241440412}
   - component: {fileID: 212892789350444872}
   - component: {fileID: 114564193246404582}
+  - component: {fileID: -2112501252169391278}
+  - component: {fileID: 7432704729882775510}
   m_Layer: 0
-  m_Name: normalHolePrefab
+  m_Name: NormalHolePrefab
   m_TagString: Bullet
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -30,9 +22,10 @@ GameObject:
   m_IsActive: 1
 --- !u!4 &4949918241440412
 Transform:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1590802889344152}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -41,24 +34,12 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &114564193246404582
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1590802889344152}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5ac7c74b850c747e2ba6890c1e0484d5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  originalWidth: 0
-  originalHeight: 0
 --- !u!212 &212892789350444872
 SpriteRenderer:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1590802889344152}
   m_Enabled: 1
   m_CastShadows: 0
@@ -68,6 +49,7 @@ SpriteRenderer:
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
   m_RenderingLayerMask: 4294967295
+  m_RendererPriority: 0
   m_Materials:
   - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
   m_StaticBatchInfo:
@@ -99,3 +81,63 @@ SpriteRenderer:
   m_SpriteTileMode: 0
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!114 &114564193246404582
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1590802889344152}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5ac7c74b850c747e2ba6890c1e0484d5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!61 &-2112501252169391278
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1590802889344152}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1.84, y: 1.72}
+    newSize: {x: 1.84, y: 1.72}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1.84, y: 1.72}
+  m_EdgeRadius: 0
+--- !u!50 &7432704729882775510
+Rigidbody2D:
+  serializedVersion: 4
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1590802889344152}
+  m_BodyType: 0
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDrag: 0
+  m_AngularDrag: 0.05
+  m_GravityScale: 1
+  m_Material: {fileID: 0}
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 0

--- a/Assets/Project/Prefabs/GamePlayScene/Bullet/Hole/aimingHolePrefab.prefab
+++ b/Assets/Project/Prefabs/GamePlayScene/Bullet/Hole/aimingHolePrefab.prefab
@@ -1,26 +1,18 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1001 &100100000
-Prefab:
-  m_ObjectHideFlags: 1
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications: []
-    m_RemovedComponents: []
-  m_ParentPrefab: {fileID: 0}
-  m_RootGameObject: {fileID: 1225760507672674}
-  m_IsPrefabParent: 1
 --- !u!1 &1225760507672674
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 5
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 4032556740731960}
   - component: {fileID: 212436271572720936}
   - component: {fileID: 114936374060992412}
+  - component: {fileID: 1768844315502914671}
+  - component: {fileID: -8451264784571383085}
   m_Layer: 0
   m_Name: aimingHolePrefab
   m_TagString: Bullet
@@ -30,9 +22,10 @@ GameObject:
   m_IsActive: 1
 --- !u!4 &4032556740731960
 Transform:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1225760507672674}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -41,24 +34,12 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &114936374060992412
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1225760507672674}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 15e93bb1090ee40df9c1955892d209e2, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  originalWidth: 0
-  originalHeight: 0
 --- !u!212 &212436271572720936
 SpriteRenderer:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1225760507672674}
   m_Enabled: 1
   m_CastShadows: 0
@@ -68,6 +49,7 @@ SpriteRenderer:
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
   m_RenderingLayerMask: 4294967295
+  m_RendererPriority: 0
   m_Materials:
   - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
   m_StaticBatchInfo:
@@ -99,3 +81,63 @@ SpriteRenderer:
   m_SpriteTileMode: 0
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!114 &114936374060992412
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1225760507672674}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 15e93bb1090ee40df9c1955892d209e2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!61 &1768844315502914671
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1225760507672674}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1.84, y: 1.72}
+    newSize: {x: 1.84, y: 1.72}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1.84, y: 1.72}
+  m_EdgeRadius: 0
+--- !u!50 &-8451264784571383085
+Rigidbody2D:
+  serializedVersion: 4
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1225760507672674}
+  m_BodyType: 0
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDrag: 0
+  m_AngularDrag: 0.05
+  m_GravityScale: 1
+  m_Material: {fileID: 0}
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 0

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/AimingHoleController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/AimingHoleController.cs
@@ -11,7 +11,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
         /// <param name="holeWarningPosition"> 警告の座標 </param>
         public void Initialize(Vector2 holeWarningPosition)
         {
-            transform.position = holeWarningPosition;
+            transform.position = new Vector3(holeWarningPosition.x, holeWarningPosition.y, speed);
             // 座標から行と列を取得する
             (row, column) = BulletLibrary.GetRowAndColumn(holeWarningPosition);
         }

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/AimingHoleGenerator.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/AimingHoleGenerator.cs
@@ -78,7 +78,6 @@ namespace Project.Scripts.GamePlayScene.Bullet
                 holeScript.Initialize(warning.transform.position);
                 // 同レイヤーのオブジェクトの描画順序の制御
                 hole.GetComponent<Renderer>().sortingOrder = bulletId;
-                StartCoroutine(holeScript.CollisionCheck());
             }
         }
 

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/BulletController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/BulletController.cs
@@ -1,5 +1,6 @@
 ﻿using UnityEngine;
 using System;
+using Project.Scripts.Utils.Attributes;
 using Project.Scripts.Utils.Definitions;
 
 namespace Project.Scripts.GamePlayScene.Bullet
@@ -23,12 +24,26 @@ namespace Project.Scripts.GamePlayScene.Bullet
         /// </summary>
         [NonSerialized] public float originalHeight;
 
+        protected GamePlayDirector gamePlayDirector;
+
+        /// <summary>
+        /// 銃弾の移動する速さ
+        /// </summary>
+        [SerializeField, NonEditable] protected float speed = 0.05f;
+
         protected virtual void Awake()
         {
+            // 元々の画像サイズの取得
             originalWidth = GetComponent<SpriteRenderer>().size.x;
             originalHeight = GetComponent<SpriteRenderer>().size.y;
             // sortingLayerの設定
             gameObject.GetComponent<Renderer>().sortingLayerName = SortingLayerName.BULLET;
+            // 衝突判定を有効にする
+            gameObject.GetComponent<BoxCollider2D>().isTrigger = true;
+            // 重力を用いた物理演算を行わない
+            gameObject.GetComponent<Rigidbody2D>().gravityScale = 0f;
+            // GamePlayDirectorの取得
+            gamePlayDirector = FindObjectOfType<GamePlayDirector>();
         }
 
         private void OnEnable()
@@ -49,5 +64,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
         }
 
         protected abstract void OnFail();
+
+        protected abstract void OnTriggerEnter2D(Collider2D other);
     }
 }

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/BulletController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/BulletController.cs
@@ -4,6 +4,8 @@ using Project.Scripts.Utils.Definitions;
 
 namespace Project.Scripts.GamePlayScene.Bullet
 {
+    [RequireComponent(typeof(BoxCollider2D))]
+    [RequireComponent(typeof(Rigidbody2D))]
     // Bulletに共通したフィールド、メソッドの定義
     public abstract class BulletController : MonoBehaviour
     {

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/NormalCartridgeController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/NormalCartridgeController.cs
@@ -25,7 +25,6 @@ namespace Project.Scripts.GamePlayScene.Bullet
         {
             base.Awake();
             // BocCollider2Dのアタッチメント
-            gameObject.AddComponent<BoxCollider2D>();
             // 銃弾の先頭部分のみに当たり判定を与える
             const float betweenPanels = TileSize.WIDTH - PanelSize.WIDTH;
             gameObject.GetComponent<BoxCollider2D>().offset =
@@ -34,7 +33,6 @@ namespace Project.Scripts.GamePlayScene.Bullet
                 new Vector2(betweenPanels, originalHeight);
             gameObject.GetComponent<BoxCollider2D>().isTrigger = true;
             // RigidBodyのアタッチメント
-            gameObject.AddComponent<Rigidbody2D>();
             gameObject.GetComponent<Rigidbody2D>().gravityScale = 0f;
         }
 

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/NormalCartridgeController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/NormalCartridgeController.cs
@@ -1,5 +1,4 @@
 using System;
-using Project.Scripts.Utils.Attributes;
 using Project.Scripts.Utils.Definitions;
 using Project.Scripts.Utils.Library.Extension;
 using UnityEngine;
@@ -16,24 +15,16 @@ namespace Project.Scripts.GamePlayScene.Bullet
         /// 銃弾の移動ベクトル
         /// </summary>
         [NonSerialized] public Vector2 motionVector;
-        /// <summary>
-        /// 銃弾の移動する速さ
-        /// </summary>
-        [SerializeField, NonEditable] protected float speed = 0.05f;
 
         protected override void Awake()
         {
             base.Awake();
-            // BocCollider2Dのアタッチメント
             // 銃弾の先頭部分のみに当たり判定を与える
             const float betweenPanels = TileSize.WIDTH - PanelSize.WIDTH;
             gameObject.GetComponent<BoxCollider2D>().offset =
                 new Vector2(-(originalWidth - betweenPanels) / 2, 0);
             gameObject.GetComponent<BoxCollider2D>().size =
                 new Vector2(betweenPanels, originalHeight);
-            gameObject.GetComponent<BoxCollider2D>().isTrigger = true;
-            // RigidBodyのアタッチメント
-            gameObject.GetComponent<Rigidbody2D>().gravityScale = 0f;
         }
 
         /// <summary>
@@ -100,7 +91,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
             speed = 0;
         }
 
-        private void OnTriggerEnter2D(Collider2D other)
+        protected override void OnTriggerEnter2D(Collider2D other)
         {
             // 数字パネルとの衝突以外は考えない
             if (!other.gameObject.CompareTag(TagName.NUMBER_PANEL)) return;

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/NormalHoleController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/NormalHoleController.cs
@@ -39,7 +39,21 @@ namespace Project.Scripts.GamePlayScene.Bullet
         {
             this.row = row;
             this.column = column;
-            transform.position = holeWarningPosition;
+            // 銃痕のz座標が0のときのみ衝突判定を行う
+            // 銃痕の出現直後の1フレームで奥行き方向に移動する分を加算しておく
+            transform.position = new Vector3(holeWarningPosition.x, holeWarningPosition.y, speed);
+        }
+
+        protected void Update()
+        {
+            // 50フレーム以上経過していたら銃弾を消す
+            if (transform.position.z < (-1) * 50 * speed && gamePlayDirector.state == GamePlayDirector.EGameState.Playing) Destroy(gameObject);
+        }
+
+        protected void FixedUpdate()
+        {
+            // 奥行き方向に移動させる(見た目の変化はない)
+            transform.Translate(new Vector3(0, 0, -1) * speed, Space.World);
         }
 
         protected override void OnFail()
@@ -76,6 +90,17 @@ namespace Project.Scripts.GamePlayScene.Bullet
                 yield return new WaitForSeconds(_HOLE_DISPLAYED_TIME);
                 Destroy(gameObject);
             }
+        }
+
+        protected override void OnTriggerEnter2D(Collider2D other)
+        {
+            // 数字パネルとの衝突以外は考えない
+            if (!other.gameObject.CompareTag(TagName.NUMBER_PANEL)) return;
+            // 銃痕(hole)が出現したフレーム以外では衝突を考えない
+            if (transform.position.z < 0) return;
+
+            // 衝突したオブジェクトは赤色に変える
+            gameObject.GetComponent<SpriteRenderer>().color = Color.red;
         }
     }
 }

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/NormalHoleController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/NormalHoleController.cs
@@ -1,4 +1,5 @@
 ﻿using UnityEngine;
+using System;
 using System.Collections;
 using Project.Scripts.Utils.Definitions;
 using Project.Scripts.Utils.Library;
@@ -49,6 +50,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
         /// NumberPanelとの当たり判定
         /// </summary>
         /// <returns></returns>
+        [Obsolete("このメソッドは使われておりません")]
         public IEnumerator CollisionCheck()
         {
             var gamePlayDirector = FindObjectOfType<GamePlayDirector>();

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/NormalHoleController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/NormalHoleController.cs
@@ -26,8 +26,6 @@ namespace Project.Scripts.GamePlayScene.Bullet
             base.Awake();
             transform.localScale = new Vector2(HoleSize.WIDTH / originalWidth, HoleSize.HEIGHT / originalHeight) *
             LOCAL_SCALE;
-            gameObject.GetComponent<BoxCollider2D>().isTrigger = true;
-            gameObject.GetComponent<Rigidbody2D>().gravityScale = 0f;
         }
 
         /// <summary>

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/NormalHoleController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/NormalHoleController.cs
@@ -9,9 +9,11 @@ namespace Project.Scripts.GamePlayScene.Bullet
     public class NormalHoleController : BulletController
     {
         /// <summary>
-        /// 表示時間
+        /// 表示フレーム数
         /// </summary>
-        private const float _HOLE_DISPLAYED_TIME = 0.50f;
+        private const int _HOLE_DISPLAYED_FRAMES = 25;
+
+
 
         /// <summary>
         /// 出現する行
@@ -46,8 +48,8 @@ namespace Project.Scripts.GamePlayScene.Bullet
 
         protected void Update()
         {
-            // 50フレーム以上経過していたら銃弾を消す
-            if (transform.position.z < (-1) * 50 * speed && gamePlayDirector.state == GamePlayDirector.EGameState.Playing) Destroy(gameObject);
+            // 指定のフレーム以上経過していたら銃弾を消す
+            if (transform.position.z < (-1) * _HOLE_DISPLAYED_FRAMES * speed && gamePlayDirector.state == GamePlayDirector.EGameState.Playing) Destroy(gameObject);
         }
 
         protected void FixedUpdate()
@@ -80,14 +82,14 @@ namespace Project.Scripts.GamePlayScene.Bullet
                 } else {
                     // 銃弾の出現するタイル上に数字パネル以外のタイルが存在する
                     // 当たり判定は起きない
-                    yield return new WaitForSeconds(_HOLE_DISPLAYED_TIME);
+                    yield return new WaitForSeconds(_HOLE_DISPLAYED_FRAMES / 50);
                     Destroy(gameObject);
                 }
             } else {
                 // 銃弾の出現するタイル上にパネルが存在しない
                 // タイルとパネルの間のレイヤー(Hole)に描画する
                 gameObject.GetComponent<Renderer>().sortingLayerName = SortingLayerName.HOLE;
-                yield return new WaitForSeconds(_HOLE_DISPLAYED_TIME);
+                yield return new WaitForSeconds(_HOLE_DISPLAYED_FRAMES / 50);
                 Destroy(gameObject);
             }
         }

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/NormalHoleController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/NormalHoleController.cs
@@ -55,7 +55,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
         protected void FixedUpdate()
         {
             // 奥行き方向に移動させる(見た目の変化はない)
-            transform.Translate(new Vector3(0, 0, -1) * speed, Space.World);
+            transform.Translate(Vector3.back * speed, Space.World);
         }
 
         protected override void OnFail()

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/NormalHoleController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/NormalHoleController.cs
@@ -26,6 +26,8 @@ namespace Project.Scripts.GamePlayScene.Bullet
             base.Awake();
             transform.localScale = new Vector2(HoleSize.WIDTH / originalWidth, HoleSize.HEIGHT / originalHeight) *
             LOCAL_SCALE;
+            gameObject.GetComponent<BoxCollider2D>().isTrigger = true;
+            gameObject.GetComponent<Rigidbody2D>().gravityScale = 0f;
         }
 
         /// <summary>

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/NormalHoleController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/NormalHoleController.cs
@@ -11,9 +11,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
         /// <summary>
         /// 表示フレーム数
         /// </summary>
-        private const int _HOLE_DISPLAYED_FRAMES = 25;
-
-
+        private const int HOLE_DISPLAYED_FRAMES = 25;
 
         /// <summary>
         /// 出現する行
@@ -49,7 +47,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
         protected void Update()
         {
             // 指定のフレーム以上経過していたら銃弾を消す
-            if (transform.position.z < (-1) * _HOLE_DISPLAYED_FRAMES * speed && gamePlayDirector.state == GamePlayDirector.EGameState.Playing) Destroy(gameObject);
+            if (transform.position.z < (-1) * HOLE_DISPLAYED_FRAMES * speed && gamePlayDirector.state == GamePlayDirector.EGameState.Playing) Destroy(gameObject);
         }
 
         protected void FixedUpdate()
@@ -82,14 +80,14 @@ namespace Project.Scripts.GamePlayScene.Bullet
                 } else {
                     // 銃弾の出現するタイル上に数字パネル以外のタイルが存在する
                     // 当たり判定は起きない
-                    yield return new WaitForSeconds(_HOLE_DISPLAYED_FRAMES / 50);
+                    yield return new WaitForSeconds(HOLE_DISPLAYED_FRAMES / 50);
                     Destroy(gameObject);
                 }
             } else {
                 // 銃弾の出現するタイル上にパネルが存在しない
                 // タイルとパネルの間のレイヤー(Hole)に描画する
                 gameObject.GetComponent<Renderer>().sortingLayerName = SortingLayerName.HOLE;
-                yield return new WaitForSeconds(_HOLE_DISPLAYED_FRAMES / 50);
+                yield return new WaitForSeconds(HOLE_DISPLAYED_FRAMES / 50);
                 Destroy(gameObject);
             }
         }

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/NormalHoleGenerator.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/NormalHoleGenerator.cs
@@ -89,7 +89,6 @@ namespace Project.Scripts.GamePlayScene.Bullet
                 holeScript.Initialize(nextHoleRow, nextHoleColumn, warning.transform.position);
                 // 同レイヤーのオブジェクトの描画順序の制御
                 hole.GetComponent<Renderer>().sortingOrder = bulletId;
-                StartCoroutine(holeScript.CollisionCheck());
             }
         }
 

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/TurnCartridgeController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/TurnCartridgeController.cs
@@ -24,8 +24,6 @@ namespace Project.Scripts.GamePlayScene.Bullet
         /// </summary>
         [SerializeField] private GameObject _normalCartridgeWarningPrefab;
 
-        private GamePlayDirector _gamePlayDirector;
-
         /// <summary>
         /// 警告を表示するフレームの配列
         /// </summary>
@@ -86,12 +84,11 @@ namespace Project.Scripts.GamePlayScene.Bullet
         protected override void Awake()
         {
             base.Awake();
-            _gamePlayDirector = FindObjectOfType<GamePlayDirector>();
         }
 
         protected override void FixedUpdate()
         {
-            if (_gamePlayDirector.state == GamePlayDirector.EGameState.Playing) {
+            if (gamePlayDirector.state == GamePlayDirector.EGameState.Playing) {
                 // 警告を表示するタイミングかどうかを毎フレーム監視する
                 _warningTiming[_warningIndex]--;
                 if (_warningTiming[_warningIndex] == 0) {

--- a/Assets/Project/Scripts/GamePlayScene/Panel/LifeNumberPanelController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Panel/LifeNumberPanelController.cs
@@ -37,7 +37,7 @@ namespace Project.Scripts.GamePlayScene.Panel
         /// <param name="other">The other Collider2D involved in this collision.</param>
         private void OnTriggerEnter2D(Collider2D other)
         {
-            if (other.tag == TagName.BULLET) {
+            if (other.tag == TagName.BULLET && other.gameObject.transform.position.z >= 0) {
                 --_currentLife;
                 if (_currentLife <= 0) {
                     _anim.Play(_deadAnimation.name, PlayMode.StopAll);

--- a/Assets/Project/Scripts/GamePlayScene/Panel/NumberPanelController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Panel/NumberPanelController.cs
@@ -98,6 +98,8 @@ namespace Project.Scripts.GamePlayScene.Panel
         {
             // 銃弾との衝突以外は考えない（現状は，パネル同士での衝突は起こりえない）
             if (!other.gameObject.CompareTag(TagName.BULLET)) return;
+            // 銃痕(hole)が出現したフレーム以外では衝突を考えない
+            if (other.gameObject.transform.position.z < 0) return;
 
             // 失敗演出
             _anim.Play(_deadAnimation.name, PlayMode.StopAll);

--- a/Assets/Project/Scripts/GamePlayScene/StageGenerator.cs
+++ b/Assets/Project/Scripts/GamePlayScene/StageGenerator.cs
@@ -365,6 +365,36 @@ namespace Project.Scripts.GamePlayScene
                     panelGenerator.CreateDynamicDummyPanel(initialTileNum: 3);
                     panelGenerator.CreateStaticDummyPanel(initialTileNum: 15);
                     break;
+                case 1003:
+                    // ライフ付きパネル
+                    // 銃弾実体生成
+                    // ランダムな銃弾をランダムな引数で生成する
+                    coroutines.Add(bulletGroupGenerator.CreateBulletGroup(
+                            appearanceTime: 1.0f,
+                            interval: 5.0f,
+                            loop: true,
+                    bulletGenerators: new List<GameObject>() {
+                        bulletGroupGenerator.CreateRandomNormalHoleGenerator(10, new int[] {1, 1, 1, 1, 1}, new int[] {1, 1, 1}),
+                                                                             bulletGroupGenerator.CreateRandomAimingHoleGenerator(10, new int[] {1, 1, 1, 1, 1, 1, 1, 1})
+                    }));
+                    /* 特殊タイル -> 数字パネル -> 特殊パネル */
+                    // 数字パネル作成
+                    panelGenerator.PrepareTilesAndCreateLifeNumberPanels(
+                    new List<Dictionary<string, int>>() {
+                        PanelGenerator.ComvartToDictionary(panelNum: 1, initialTileNum: 4, finalTileNum: 4),
+                                                           PanelGenerator.ComvartToDictionary(panelNum: 2, initialTileNum: 5, finalTileNum: 5),
+                                                           PanelGenerator.ComvartToDictionary(panelNum: 3, initialTileNum: 6, finalTileNum: 6),
+                                                           PanelGenerator.ComvartToDictionary(panelNum: 4, initialTileNum: 7, finalTileNum: 7),
+                                                           PanelGenerator.ComvartToDictionary(panelNum: 5, initialTileNum: 8, finalTileNum: 8),
+                                                           PanelGenerator.ComvartToDictionary(panelNum: 6, initialTileNum: 9, finalTileNum: 9),
+                                                           PanelGenerator.ComvartToDictionary(panelNum: 7, initialTileNum: 10, finalTileNum: 10),
+                                                           PanelGenerator.ComvartToDictionary(panelNum: 8, initialTileNum: 14, finalTileNum: 11)
+                    }
+                    );
+                    // 特殊パネル作成
+                    panelGenerator.CreateDynamicDummyPanel(initialTileNum: 3);
+                    panelGenerator.CreateStaticDummyPanel(initialTileNum: 15);
+                    break;
                 default:
                     throw new NotImplementedException();
             }


### PR DESCRIPTION
## 対象イシュー
Close #163

## 概要
撃ち抜く銃弾(`NormalHole, AimingHole`)を`BoxCollider2D, RigidBody2D`を用いた実装に変更しました。

## 技術的な内容
- `[RequireComponent]`を用いて銃弾の`component`を指定しました。
- 撃ち抜く銃弾(hole)にも`BoxCollider2D, Rigidbody2D`をアタッチしたので、いくつかの変数を親クラスに移動させました。
- 撃ち抜く銃弾は時間経過でz座標の値を減少させ、当たり判定は`z>0`の時(出現直後のフレームのみ)にしました。
- ステージID : 1003のステージで、`LifeNumberPanel`と`hole`の挙動が見れます。

## その他
物体`obj_i`と物体`obj_j`の衝突時の処理の記述について。
今は、`obj_i`のスクリプトに、衝突相手が`obj_j`の時の処理を書いて、同様に、`obj_j`のスクリプトに衝突相手が`obj_i`の時の処理を書いてる。
↑`LifeNumberPanel`の`Life`を2以上減らす銃弾とか、今後、衝突時の処理が異なるオブジェクトが増えると大変そう。

`obj_i`と`obj_j`の2つを受け取り、衝突時の処理を各々に通知する管理者(gameDirectorの仕事?)みたいなスクリプト欲しいかもね。

## キャプチャ

