### PR TITLE
WIP: Third Party のライセンスを追加

### DIFF
--- a/Assets/ThirdParties/SnapScroll/LICENSE.txt
+++ b/Assets/ThirdParties/SnapScroll/LICENSE.txt
@@ -1,0 +1,8 @@
+The MIT License (MIT)
+Copyright (c) 2018 okamura0510.jp
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/Assets/ThirdParties/SnapScroll/LICENSE.txt.meta
+++ b/Assets/ThirdParties/SnapScroll/LICENSE.txt.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: dbf8f09d36e046f9ba20aaf4354fe4ba
+timeCreated: 1567874044

--- a/Assets/ThirdParties/TouchScript/Editor/TouchManagerEditor.cs
+++ b/Assets/ThirdParties/TouchScript/Editor/TouchManagerEditor.cs
@@ -197,7 +197,7 @@ namespace TouchScript.Editor
                     var label = EditorGUI.BeginProperty(r, TEXT_SEND_MESSAGE_EVENTS, sendMessageEvents);
                     EditorGUI.BeginChangeCheck();
                     r = EditorGUI.PrefixLabel(r, label);
-                    var sMask = (TouchManager.MessageType)EditorGUI.EnumMaskField(r, instance.SendMessageEvents);
+                    var sMask = (TouchManager.MessageType)EditorGUI.EnumFlagsField(r, instance.SendMessageEvents);
 
                     if (EditorGUI.EndChangeCheck()) {
                         instance.SendMessageEvents = sMask;

--- a/Assets/ThirdParties/TouchScript/Scripts/Devices/Display/GenericDisplayDevice.cs
+++ b/Assets/ThirdParties/TouchScript/Scripts/Devices/Display/GenericDisplayDevice.cs
@@ -82,7 +82,7 @@ namespace TouchScript.Devices.Display
                 // Mobiles / fullscreen
                 case RuntimePlatform.Android:
                 case RuntimePlatform.IPhonePlayer:
-                case RuntimePlatform.TizenPlayer:
+                // case RuntimePlatform.TizenPlayer:
                 case RuntimePlatform.WSAPlayerARM:
                 case RuntimePlatform.WSAPlayerX64:
                 case RuntimePlatform.WSAPlayerX86:
@@ -119,9 +119,9 @@ namespace TouchScript.Devices.Display
                     break;
 
                 // Probably TVs
-                case RuntimePlatform.SamsungTVPlayer:
+                // case RuntimePlatform.SamsungTVPlayer:
                 case RuntimePlatform.Switch:
-                case RuntimePlatform.WiiU:
+                // case RuntimePlatform.WiiU:
                 case RuntimePlatform.XboxOne:
                 case RuntimePlatform.tvOS:
 
@@ -134,9 +134,11 @@ namespace TouchScript.Devices.Display
                     nativeResolution = new Vector2(res.width, res.height);
                     break;
 
+                /*
                 case RuntimePlatform.PSP2:
                     nativeResolution = new Vector2(960, 544);
                     break;
+                */
 
                 default:
 
@@ -236,7 +238,7 @@ namespace TouchScript.Devices.Display
                 // Mobiles / fullscreen
                 case RuntimePlatform.Android:
                 case RuntimePlatform.IPhonePlayer:
-                case RuntimePlatform.TizenPlayer:
+                // case RuntimePlatform.TizenPlayer:
                 case RuntimePlatform.WSAPlayerARM:
                 case RuntimePlatform.WSAPlayerX64:
                 case RuntimePlatform.WSAPlayerX86:
@@ -244,9 +246,9 @@ namespace TouchScript.Devices.Display
                     break;
 
                 // Probably TVs
-                case RuntimePlatform.SamsungTVPlayer:
+                // case RuntimePlatform.SamsungTVPlayer:
                 case RuntimePlatform.Switch:
-                case RuntimePlatform.WiiU:
+                // case RuntimePlatform.WiiU:
                 case RuntimePlatform.XboxOne:
                 case RuntimePlatform.tvOS:
 
@@ -261,9 +263,11 @@ namespace TouchScript.Devices.Display
 
                     break;
 
+                /*
                 case RuntimePlatform.PSP2:
                     nativeDPI = 220.68f;
                     break;
+                */
 
                 default:
                     // This has not been tested and is probably wrong.


### PR DESCRIPTION
## 対象イシュー
Close #164 

## 概要
- 当初の目的とは変わったが，ライセンス問題を明らかにした
- 現状 develop に存在する Third Party スクリプトは TouchScript，SpriteGlow，SnapScrollである．これらのライセンスは全て MIT ライセンスで，性質は以下となる．(#164 参照)

https://wisdommingle.com/mit-license/
> MITライセンス（エムアイティーライセンス）（MIT License）というのは、オープンソースソフトウェアのライセンスのひとつで、無料で自由につかうことができる（制限がほんのすこししかない）のが特徴です。 (*1)
> 
> MITライセンスのもとで配布されているものは、改変でも、再配布でも、商用利用でも、有料販売でも、どんなことにでも自由に無料でつかうことができます。
> 
> そのために守らなくてはいけない条件は、「著作権表示」と「MITライセンスの全文」を記載する、という条件だけです。（なお、「MITライセンスの全文」を記載する代わりに、MITライセンスの全文が記載されているウェブページのURLを記載することも認められています。）

よって，TouchScriptとSpriteGlowに関しては，すでにライセンステキストがgitに含まれていて，SnapScrollだけが含まれていなかったので，追加した．
今後追加される Third Partyスクリプトに関しては全て責任を持ってライセンスを確認してください．

