### PR TITLE
言葉を全て多言語に対応させる

### DIFF
--- a/Assets/Project/Resources/GameDatas/translation.csv
+++ b/Assets/Project/Resources/GameDatas/translation.csv
@@ -4,7 +4,7 @@ ConfigReset,リセット,Reset
 ConfigVibration,振動,Vibration
 ConfigVolume,音量,Volume
 GameFailure,失敗,Failure
-GameSuccess,成功,GameSuccess
+GameSuccess,成功,Success
 GameResult,結果,Result
 GameRetry,リトライ,Retry
 GameWarning,アプリがバックグラウンドに移動しました,The app has moved to the background

--- a/Assets/Project/Resources/GameDatas/translation.csv
+++ b/Assets/Project/Resources/GameDatas/translation.csv
@@ -10,9 +10,9 @@ GameRetry,リトライ,Retry
 GameWarning,アプリがバックグラウンドに移動しました,The app has moved to the background
 LanguageJapanese,日本語,Japanese
 LanguageEnglish,英語,English
-StageFirst,かんたん,Easy
-StageSecond,ふつう,Normal
-StageThird,むずかしい,Hard
-StageFourth,げきむず,VeryHard 
+LevelFirst,かんたん,Easy
+LevelSecond,ふつう,Normal
+LevelThird,むずかしい,Hard
+LevelFourth,げきむず,VeryHard 
 Turorial,あそびかた,Tutorial
 GameTweet,投稿,Tweet

--- a/Assets/Project/Resources/GameDatas/translation.csv
+++ b/Assets/Project/Resources/GameDatas/translation.csv
@@ -1,5 +1,17 @@
 enum,JP,EN
-Success,成功,Success
-Failed,失敗,Failed
 Config,設定,Setting
-Retry,リトライ,Retry
+ConfigReset,リセット,Reset
+ConfigVibration,振動,Vibration
+ConfigVolume,音量,Volume
+GameFailure,失敗,Failure
+GameSuccess,成功,GameSuccess
+GameResult,結果,Result
+GameRetry,リトライ,Retry
+GameWarning,アプリがバックグラウンドに移動しました,The app has moved to the background
+LanguageJapanese,日本語,Japanese
+LanguageEnglish,英語,English
+StageFirst,かんたん,Easy
+StageSecond,ふつう,Normal
+StageThird,むずかしい,Hard
+StageFourth,げきむず,VeryHard 
+Turorial,あそびかた,Tutorial

--- a/Assets/Project/Resources/GameDatas/translation.csv
+++ b/Assets/Project/Resources/GameDatas/translation.csv
@@ -15,3 +15,4 @@ StageSecond,ふつう,Normal
 StageThird,むずかしい,Hard
 StageFourth,げきむず,VeryHard 
 Turorial,あそびかた,Tutorial
+GameTweet,投稿,Tweet

--- a/Assets/Project/Resources/GameDatas/translation.csv
+++ b/Assets/Project/Resources/GameDatas/translation.csv
@@ -8,8 +8,8 @@ GameSuccess,成功,Success
 GameResult,結果,Result
 GameRetry,リトライ,Retry
 GameWarning,アプリがバックグラウンドに移動しました,The app has moved to the background
-LanguageJapanese,日本語,Japanese
-LanguageEnglish,英語,English
+LanguageJapanese,日本語,日本語
+LanguageEnglish,English,English
 LevelFirst,かんたん,Easy
 LevelSecond,ふつう,Normal
 LevelThird,むずかしい,Hard

--- a/Assets/Project/Scenes/ConfigScene.unity
+++ b/Assets/Project/Scenes/ConfigScene.unity
@@ -717,7 +717,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 125786991}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: 6095efb3f7c9740c28c449abd9d848b0, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
@@ -734,7 +734,7 @@ MonoBehaviour:
     m_FontStyle: 0
     m_BestFit: 1
     m_MinSize: 10
-    m_MaxSize: 100
+    m_MaxSize: 40
     m_Alignment: 3
     m_AlignByGeometry: 0
     m_RichText: 1
@@ -742,6 +742,7 @@ MonoBehaviour:
     m_VerticalOverflow: 0
     m_LineSpacing: 1
   m_Text: "\u97F3\u91CF"
+  _textIndex: 3
 --- !u!222 &125786994
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -749,6 +750,86 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 125786991}
+  m_CullTransparentMesh: 0
+--- !u!1 &232928215
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 232928216}
+  - component: {fileID: 232928218}
+  - component: {fileID: 232928217}
+  m_Layer: 5
+  m_Name: EnglishText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &232928216
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 232928215}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.95, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1715909543}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.05, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &232928217
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 232928215}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6095efb3f7c9740c28c449abd9d848b0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 14
+    m_FontStyle: 0
+    m_BestFit: 1
+    m_MinSize: 10
+    m_MaxSize: 40
+    m_Alignment: 3
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: "\u82F1\u8A9E"
+  _textIndex: 10
+--- !u!222 &232928218
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 232928215}
   m_CullTransparentMesh: 0
 --- !u!1 &235699698
 GameObject:
@@ -1110,7 +1191,7 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
-  - {fileID: 1631403661}
+  - {fileID: 1221212381}
   m_Father: {fileID: 1237425347}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -1498,7 +1579,7 @@ MonoBehaviour:
     m_VerticalOverflow: 0
     m_LineSpacing: 1
   m_Text: "\u8A2D\u5B9A"
-  _textIndex: 2
+  _textIndex: 0
 --- !u!222 &437239863
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -3024,7 +3105,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 1112527332}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: 6095efb3f7c9740c28c449abd9d848b0, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
@@ -3041,7 +3122,7 @@ MonoBehaviour:
     m_FontStyle: 0
     m_BestFit: 1
     m_MinSize: 10
-    m_MaxSize: 100
+    m_MaxSize: 40
     m_Alignment: 3
     m_AlignByGeometry: 0
     m_RichText: 1
@@ -3049,6 +3130,7 @@ MonoBehaviour:
     m_VerticalOverflow: 0
     m_LineSpacing: 1
   m_Text: "\u632F\u52D5"
+  _textIndex: 2
 --- !u!222 &1112527335
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -3146,6 +3228,86 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1165585008}
+  m_CullTransparentMesh: 0
+--- !u!1 &1221212380
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1221212381}
+  - component: {fileID: 1221212383}
+  - component: {fileID: 1221212382}
+  m_Layer: 5
+  m_Name: JapaneseText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1221212381
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1221212380}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.95, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 385533603}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.05, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1221212382
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1221212380}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6095efb3f7c9740c28c449abd9d848b0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 14
+    m_FontStyle: 0
+    m_BestFit: 1
+    m_MinSize: 10
+    m_MaxSize: 40
+    m_Alignment: 3
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: "\u65E5\u672C\u8A9E"
+  _textIndex: 9
+--- !u!222 &1221212383
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1221212380}
   m_CullTransparentMesh: 0
 --- !u!1 &1225547384
 GameObject:
@@ -3384,7 +3546,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 1353298366}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: 6095efb3f7c9740c28c449abd9d848b0, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
@@ -3401,14 +3563,15 @@ MonoBehaviour:
     m_FontStyle: 0
     m_BestFit: 1
     m_MinSize: 10
-    m_MaxSize: 100
+    m_MaxSize: 40
     m_Alignment: 3
     m_AlignByGeometry: 0
     m_RichText: 1
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: "\u30B9\u30C6\u30FC\u30B8\u30EA\u30BB\u30C3\u30C8"
+  m_Text: "\u30EA\u30BB\u30C3\u30C8"
+  _textIndex: 1
 --- !u!222 &1353298369
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -3680,85 +3843,6 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 1}
---- !u!1 &1631403660
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1631403661}
-  - component: {fileID: 1631403663}
-  - component: {fileID: 1631403662}
-  m_Layer: 5
-  m_Name: Text
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &1631403661
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1631403660}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 385533603}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &1631403662
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1631403660}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
-  m_RaycastTarget: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  m_FontData:
-    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
-    m_FontSize: 14
-    m_FontStyle: 0
-    m_BestFit: 1
-    m_MinSize: 10
-    m_MaxSize: 100
-    m_Alignment: 4
-    m_AlignByGeometry: 0
-    m_RichText: 1
-    m_HorizontalOverflow: 0
-    m_VerticalOverflow: 0
-    m_LineSpacing: 1
-  m_Text: "\u65E5\u672C\u8A9E"
---- !u!222 &1631403663
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1631403660}
-  m_CullTransparentMesh: 0
 --- !u!1 &1715909542
 GameObject:
   m_ObjectHideFlags: 0
@@ -3790,7 +3874,7 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
-  - {fileID: 1972750147}
+  - {fileID: 232928216}
   m_Father: {fileID: 1237425347}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -4219,85 +4303,6 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1927802295}
-  m_CullTransparentMesh: 0
---- !u!1 &1972750146
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1972750147}
-  - component: {fileID: 1972750149}
-  - component: {fileID: 1972750148}
-  m_Layer: 5
-  m_Name: Text
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &1972750147
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1972750146}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1715909543}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &1972750148
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1972750146}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
-  m_RaycastTarget: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  m_FontData:
-    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
-    m_FontSize: 14
-    m_FontStyle: 0
-    m_BestFit: 1
-    m_MinSize: 10
-    m_MaxSize: 100
-    m_Alignment: 4
-    m_AlignByGeometry: 0
-    m_RichText: 1
-    m_HorizontalOverflow: 0
-    m_VerticalOverflow: 0
-    m_LineSpacing: 1
-  m_Text: "\u82F1\u8A9E"
---- !u!222 &1972750149
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1972750146}
   m_CullTransparentMesh: 0
 --- !u!1 &1979720088
 GameObject:

--- a/Assets/Project/Scenes/ConfigScene.unity
+++ b/Assets/Project/Scenes/ConfigScene.unity
@@ -741,7 +741,7 @@ MonoBehaviour:
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: "\u97F3\u91CF"
+  m_Text: Volume
   _textIndex: 3
 --- !u!222 &125786994
 CanvasRenderer:
@@ -778,12 +778,12 @@ RectTransform:
   m_GameObject: {fileID: 232928215}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0.95, y: 1, z: 1}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 1715909543}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.05, y: 0}
+  m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
@@ -815,13 +815,13 @@ MonoBehaviour:
     m_BestFit: 1
     m_MinSize: 10
     m_MaxSize: 40
-    m_Alignment: 3
+    m_Alignment: 4
     m_AlignByGeometry: 0
     m_RichText: 1
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: "\u82F1\u8A9E"
+  m_Text: English
   _textIndex: 10
 --- !u!222 &232928218
 CanvasRenderer:
@@ -1578,7 +1578,7 @@ MonoBehaviour:
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: "\u8A2D\u5B9A"
+  m_Text: Setting
   _textIndex: 0
 --- !u!222 &437239863
 CanvasRenderer:
@@ -3129,7 +3129,7 @@ MonoBehaviour:
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: "\u632F\u52D5"
+  m_Text: Vibration
   _textIndex: 2
 --- !u!222 &1112527335
 CanvasRenderer:
@@ -3256,12 +3256,12 @@ RectTransform:
   m_GameObject: {fileID: 1221212380}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0.95, y: 1, z: 1}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 385533603}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.05, y: 0}
+  m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
@@ -3293,13 +3293,13 @@ MonoBehaviour:
     m_BestFit: 1
     m_MinSize: 10
     m_MaxSize: 40
-    m_Alignment: 3
+    m_Alignment: 4
     m_AlignByGeometry: 0
     m_RichText: 1
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: "\u65E5\u672C\u8A9E"
+  m_Text: Japanese
   _textIndex: 9
 --- !u!222 &1221212383
 CanvasRenderer:
@@ -3570,7 +3570,7 @@ MonoBehaviour:
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: "\u30EA\u30BB\u30C3\u30C8"
+  m_Text: Reset
   _textIndex: 1
 --- !u!222 &1353298369
 CanvasRenderer:

--- a/Assets/Project/Scenes/ConfigScene.unity
+++ b/Assets/Project/Scenes/ConfigScene.unity
@@ -1114,11 +1114,11 @@ RectTransform:
   m_Father: {fileID: 1237425347}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -138, y: 0}
-  m_SizeDelta: {x: 194.9, y: 82.4}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_AnchorMin: {x: 0.1, y: 0.1}
+  m_AnchorMax: {x: 0.4, y: 0.9}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.25, y: 0.5}
 --- !u!114 &385533604
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -3794,11 +3794,11 @@ RectTransform:
   m_Father: {fileID: 1237425347}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 135, y: 0}
-  m_SizeDelta: {x: 194.9, y: 82.4}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_AnchorMin: {x: 0.6, y: 0.1}
+  m_AnchorMax: {x: 0.9, y: 0.9}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.75, y: 0.5}
 --- !u!114 &1715909544
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Project/Scenes/GamePlayScene.unity
+++ b/Assets/Project/Scenes/GamePlayScene.unity
@@ -924,13 +924,13 @@ MonoBehaviour:
     m_BestFit: 1
     m_MinSize: 0
     m_MaxSize: 40
-    m_Alignment: 3
+    m_Alignment: 4
     m_AlignByGeometry: 0
     m_RichText: 1
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: "\u7D50\u679C"
+  m_Text: Result
   _textIndex: 6
 --- !u!222 &1130975818
 CanvasRenderer:
@@ -1093,18 +1093,18 @@ MonoBehaviour:
       Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_FontData:
     m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
-    m_FontSize: 14
+    m_FontSize: 10
     m_FontStyle: 0
-    m_BestFit: 1
-    m_MinSize: 10
+    m_BestFit: 0
+    m_MinSize: 0
     m_MaxSize: 40
-    m_Alignment: 3
+    m_Alignment: 4
     m_AlignByGeometry: 0
     m_RichText: 1
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: "\u30A2\u30D7\u30EA\u304C\u30D0\u30C3\u30AF\u30B0\u30E9\u30A6\u30F3\u30C9\u306B\u79FB\u52D5\u3057\u307E\u3057\u305F"
+  m_Text: The app has moved to the background
   _textIndex: 8
 --- !u!222 &1559380474
 CanvasRenderer:
@@ -1486,13 +1486,13 @@ MonoBehaviour:
     m_BestFit: 1
     m_MinSize: 10
     m_MaxSize: 40
-    m_Alignment: 3
+    m_Alignment: 4
     m_AlignByGeometry: 0
     m_RichText: 1
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: "\u30EA\u30C8\u30E9\u30A4"
+  m_Text: Retry
   _textIndex: 7
 --- !u!222 &1938940410
 CanvasRenderer:

--- a/Assets/Project/Scenes/GamePlayScene.unity
+++ b/Assets/Project/Scenes/GamePlayScene.unity
@@ -855,8 +855,8 @@ GameObject:
   m_Component:
   - component: {fileID: 1130975815}
   - component: {fileID: 1130975818}
-  - component: {fileID: 1130975817}
   - component: {fileID: 1130975816}
+  - component: {fileID: 1130975817}
   m_Layer: 5
   m_Name: Result
   m_TagString: Untagged
@@ -906,11 +906,11 @@ MonoBehaviour:
   m_GameObject: {fileID: 1130975814}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: 6095efb3f7c9740c28c449abd9d848b0, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0.1254902, g: 0.1254902, b: 0.1254902, a: 1}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
   m_RaycastTarget: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
@@ -921,16 +921,17 @@ MonoBehaviour:
     m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
     m_FontSize: 40
     m_FontStyle: 0
-    m_BestFit: 0
+    m_BestFit: 1
     m_MinSize: 0
-    m_MaxSize: 54
-    m_Alignment: 4
+    m_MaxSize: 40
+    m_Alignment: 3
     m_AlignByGeometry: 0
     m_RichText: 1
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
   m_Text: "\u7D50\u679C"
+  _textIndex: 6
 --- !u!222 &1130975818
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -1028,8 +1029,8 @@ GameObject:
   m_Component:
   - component: {fileID: 1559380471}
   - component: {fileID: 1559380474}
-  - component: {fileID: 1559380473}
   - component: {fileID: 1559380472}
+  - component: {fileID: 1559380473}
   m_Layer: 5
   m_Name: Warning
   m_TagString: Untagged
@@ -1079,12 +1080,12 @@ MonoBehaviour:
   m_GameObject: {fileID: 1559380470}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: 6095efb3f7c9740c28c449abd9d848b0, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
-  m_RaycastTarget: 0
+  m_RaycastTarget: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
@@ -1092,18 +1093,19 @@ MonoBehaviour:
       Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_FontData:
     m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
-    m_FontSize: 15
+    m_FontSize: 14
     m_FontStyle: 0
-    m_BestFit: 0
-    m_MinSize: 0
+    m_BestFit: 1
+    m_MinSize: 10
     m_MaxSize: 40
-    m_Alignment: 4
+    m_Alignment: 3
     m_AlignByGeometry: 0
     m_RichText: 1
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: "\u8B66\u544A\u3067\u3059"
+  m_Text: "\u30A2\u30D7\u30EA\u304C\u30D0\u30C3\u30AF\u30B0\u30E9\u30A6\u30F3\u30C9\u306B\u79FB\u52D5\u3057\u307E\u3057\u305F"
+  _textIndex: 8
 --- !u!222 &1559380474
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -1466,7 +1468,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 1938940407}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: 6095efb3f7c9740c28c449abd9d848b0, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
@@ -1479,18 +1481,19 @@ MonoBehaviour:
       Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_FontData:
     m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
-    m_FontSize: 20
+    m_FontSize: 14
     m_FontStyle: 0
-    m_BestFit: 0
-    m_MinSize: 0
-    m_MaxSize: 145
-    m_Alignment: 4
+    m_BestFit: 1
+    m_MinSize: 10
+    m_MaxSize: 40
+    m_Alignment: 3
     m_AlignByGeometry: 0
     m_RichText: 1
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
   m_Text: "\u30EA\u30C8\u30E9\u30A4"
+  _textIndex: 7
 --- !u!222 &1938940410
 CanvasRenderer:
   m_ObjectHideFlags: 0

--- a/Assets/Project/Scenes/GamePlayScene.unity
+++ b/Assets/Project/Scenes/GamePlayScene.unity
@@ -166,7 +166,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 176525670}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: 6095efb3f7c9740c28c449abd9d848b0, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
@@ -179,18 +179,19 @@ MonoBehaviour:
       Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_FontData:
     m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
-    m_FontSize: 20
+    m_FontSize: 14
     m_FontStyle: 0
-    m_BestFit: 0
-    m_MinSize: 0
-    m_MaxSize: 145
+    m_BestFit: 1
+    m_MinSize: 10
+    m_MaxSize: 40
     m_Alignment: 4
     m_AlignByGeometry: 0
     m_RichText: 1
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: "\u6295\u7A3F"
+  m_Text: 
+  _textIndex: 16
 --- !u!222 &176525673
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -930,7 +931,7 @@ MonoBehaviour:
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: Result
+  m_Text: "\u7D50\u679C"
   _textIndex: 6
 --- !u!222 &1130975818
 CanvasRenderer:
@@ -1104,7 +1105,7 @@ MonoBehaviour:
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: The app has moved to the background
+  m_Text: "\u30A2\u30D7\u30EA\u304C\u30D0\u30C3\u30AF\u30B0\u30E9\u30A6\u30F3\u30C9\u306B\u79FB\u52D5\u3057\u307E\u3057\u305F"
   _textIndex: 8
 --- !u!222 &1559380474
 CanvasRenderer:
@@ -1492,7 +1493,7 @@ MonoBehaviour:
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: Retry
+  m_Text: "\u30EA\u30C8\u30E9\u30A4"
   _textIndex: 7
 --- !u!222 &1938940410
 CanvasRenderer:

--- a/Assets/Project/Scenes/RecordScene.unity
+++ b/Assets/Project/Scenes/RecordScene.unity
@@ -237,7 +237,28 @@ PrefabInstance:
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    - target: {fileID: 8189156436163919906, guid: 1fada4ca450134c96b97a9bcbaabaa69,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8189156436163919906, guid: 1fada4ca450134c96b97a9bcbaabaa69,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8189156436163919906, guid: 1fada4ca450134c96b97a9bcbaabaa69,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8189156436163919906, guid: 1fada4ca450134c96b97a9bcbaabaa69,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents:
+    - {fileID: 8189156436163919907, guid: 1fada4ca450134c96b97a9bcbaabaa69, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: 1fada4ca450134c96b97a9bcbaabaa69, type: 3}
 --- !u!224 &1065711900 stripped
 RectTransform:
@@ -245,6 +266,47 @@ RectTransform:
     type: 3}
   m_PrefabInstance: {fileID: 1065711899}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1065711901 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8189156436163919905, guid: 1fada4ca450134c96b97a9bcbaabaa69,
+    type: 3}
+  m_PrefabInstance: {fileID: 1065711899}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1065711902
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1065711901}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6095efb3f7c9740c28c449abd9d848b0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 14
+    m_FontStyle: 0
+    m_BestFit: 1
+    m_MinSize: 10
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: "\u3052\u304D\u3080\u305A"
+  _textIndex: 14
 --- !u!224 &1101688571 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 8189156437945596951, guid: 1fada4ca450134c96b97a9bcbaabaa69,
@@ -592,6 +654,8 @@ MonoBehaviour:
     type: 3}
   _successLinePrefab: {fileID: 1781992108246784, guid: 923a9a5e14eb54aa082f3884cb658373,
     type: 3}
+  _successGraphColor: {r: 0, g: 1, b: 1, a: 1}
+  _notSuccessGraphColor: {r: 1, g: 0, b: 0, a: 1}
 --- !u!1 &1585348990
 GameObject:
   m_ObjectHideFlags: 0
@@ -868,7 +932,28 @@ PrefabInstance:
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    - target: {fileID: 8189156436163919906, guid: 1fada4ca450134c96b97a9bcbaabaa69,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8189156436163919906, guid: 1fada4ca450134c96b97a9bcbaabaa69,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8189156436163919906, guid: 1fada4ca450134c96b97a9bcbaabaa69,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8189156436163919906, guid: 1fada4ca450134c96b97a9bcbaabaa69,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents:
+    - {fileID: 8189156436163919907, guid: 1fada4ca450134c96b97a9bcbaabaa69, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: 1fada4ca450134c96b97a9bcbaabaa69, type: 3}
 --- !u!224 &1797772132 stripped
 RectTransform:
@@ -876,6 +961,47 @@ RectTransform:
     type: 3}
   m_PrefabInstance: {fileID: 1797772131}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1797772133 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8189156436163919905, guid: 1fada4ca450134c96b97a9bcbaabaa69,
+    type: 3}
+  m_PrefabInstance: {fileID: 1797772131}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1797772134
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1797772133}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6095efb3f7c9740c28c449abd9d848b0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 40
+    m_FontStyle: 0
+    m_BestFit: 1
+    m_MinSize: 0
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: "\u3080\u305A\u304B\u3057\u3044"
+  _textIndex: 13
 --- !u!1 &1854286594
 GameObject:
   m_ObjectHideFlags: 0
@@ -1121,7 +1247,28 @@ PrefabInstance:
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    - target: {fileID: 8189156436163919906, guid: 1fada4ca450134c96b97a9bcbaabaa69,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8189156436163919906, guid: 1fada4ca450134c96b97a9bcbaabaa69,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8189156436163919906, guid: 1fada4ca450134c96b97a9bcbaabaa69,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8189156436163919906, guid: 1fada4ca450134c96b97a9bcbaabaa69,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents:
+    - {fileID: 8189156436163919907, guid: 1fada4ca450134c96b97a9bcbaabaa69, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: 1fada4ca450134c96b97a9bcbaabaa69, type: 3}
 --- !u!224 &1946596445 stripped
 RectTransform:
@@ -1129,6 +1276,47 @@ RectTransform:
     type: 3}
   m_PrefabInstance: {fileID: 1946596444}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1946596446 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8189156436163919905, guid: 1fada4ca450134c96b97a9bcbaabaa69,
+    type: 3}
+  m_PrefabInstance: {fileID: 1946596444}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1946596447
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1946596446}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6095efb3f7c9740c28c449abd9d848b0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 40
+    m_FontStyle: 0
+    m_BestFit: 1
+    m_MinSize: 0
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: "\u3075\u3064\u3046"
+  _textIndex: 12
 --- !u!1 &2136668776
 GameObject:
   m_ObjectHideFlags: 0
@@ -1345,5 +1533,72 @@ PrefabInstance:
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    - target: {fileID: 8189156436163919906, guid: 1fada4ca450134c96b97a9bcbaabaa69,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8189156436163919906, guid: 1fada4ca450134c96b97a9bcbaabaa69,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8189156436163919906, guid: 1fada4ca450134c96b97a9bcbaabaa69,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8189156436163919906, guid: 1fada4ca450134c96b97a9bcbaabaa69,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8189156436163919907, guid: 1fada4ca450134c96b97a9bcbaabaa69,
+        type: 3}
+      propertyPath: m_FontData.m_BestFit
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents:
+    - {fileID: 8189156436163919907, guid: 1fada4ca450134c96b97a9bcbaabaa69, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: 1fada4ca450134c96b97a9bcbaabaa69, type: 3}
+--- !u!1 &8189156436848399085 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8189156436163919905, guid: 1fada4ca450134c96b97a9bcbaabaa69,
+    type: 3}
+  m_PrefabInstance: {fileID: 8189156436848399084}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &8189156436848399086
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8189156436848399085}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6095efb3f7c9740c28c449abd9d848b0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 40
+    m_FontStyle: 0
+    m_BestFit: 1
+    m_MinSize: 0
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: "\u304B\u3093\u305F\u3093"
+  _textIndex: 11

--- a/Assets/Project/Scenes/StageSelectScene.unity
+++ b/Assets/Project/Scenes/StageSelectScene.unity
@@ -303,7 +303,8 @@ PrefabInstance:
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6427955193974127621, guid: 1a602bd4de3b94d939558ef84a111d51, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: 1a602bd4de3b94d939558ef84a111d51, type: 3}
 --- !u!224 &228284339 stripped
 RectTransform:
@@ -311,6 +312,47 @@ RectTransform:
     type: 3}
   m_PrefabInstance: {fileID: 228284338}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &228284340 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1743798302141394486, guid: 1a602bd4de3b94d939558ef84a111d51,
+    type: 3}
+  m_PrefabInstance: {fileID: 228284338}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &228284341
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 228284340}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6095efb3f7c9740c28c449abd9d848b0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 14
+    m_FontStyle: 0
+    m_BestFit: 1
+    m_MinSize: 10
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Normal
+  _textIndex: 12
 --- !u!1 &513244090
 GameObject:
   m_ObjectHideFlags: 0
@@ -681,7 +723,8 @@ PrefabInstance:
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6427955193974127621, guid: 1a602bd4de3b94d939558ef84a111d51, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: 1a602bd4de3b94d939558ef84a111d51, type: 3}
 --- !u!224 &983018845 stripped
 RectTransform:
@@ -689,6 +732,47 @@ RectTransform:
     type: 3}
   m_PrefabInstance: {fileID: 983018844}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &983018846 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1743798302141394486, guid: 1a602bd4de3b94d939558ef84a111d51,
+    type: 3}
+  m_PrefabInstance: {fileID: 983018844}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &983018847
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 983018846}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6095efb3f7c9740c28c449abd9d848b0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 14
+    m_FontStyle: 0
+    m_BestFit: 1
+    m_MinSize: 10
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: 'VeryHard '
+  _textIndex: 14
 --- !u!1 &1095860206
 GameObject:
   m_ObjectHideFlags: 0
@@ -1015,7 +1099,8 @@ PrefabInstance:
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6427955193974127621, guid: 1a602bd4de3b94d939558ef84a111d51, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: 1a602bd4de3b94d939558ef84a111d51, type: 3}
 --- !u!224 &1734149336 stripped
 RectTransform:
@@ -1023,6 +1108,47 @@ RectTransform:
     type: 3}
   m_PrefabInstance: {fileID: 1734149335}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1734149337 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1743798302141394486, guid: 1a602bd4de3b94d939558ef84a111d51,
+    type: 3}
+  m_PrefabInstance: {fileID: 1734149335}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1734149338
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1734149337}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6095efb3f7c9740c28c449abd9d848b0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 14
+    m_FontStyle: 0
+    m_BestFit: 1
+    m_MinSize: 10
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Easy
+  _textIndex: 11
 --- !u!1001 &1816831020
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1140,7 +1266,8 @@ PrefabInstance:
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6427955193974127621, guid: 1a602bd4de3b94d939558ef84a111d51, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: 1a602bd4de3b94d939558ef84a111d51, type: 3}
 --- !u!224 &1816831021 stripped
 RectTransform:
@@ -1148,6 +1275,47 @@ RectTransform:
     type: 3}
   m_PrefabInstance: {fileID: 1816831020}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1816831022 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1743798302141394486, guid: 1a602bd4de3b94d939558ef84a111d51,
+    type: 3}
+  m_PrefabInstance: {fileID: 1816831020}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1816831023
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1816831022}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6095efb3f7c9740c28c449abd9d848b0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 14
+    m_FontStyle: 0
+    m_BestFit: 1
+    m_MinSize: 10
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Hard
+  _textIndex: 13
 --- !u!1 &1855029234
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Project/Scenes/TutorialScene.unity
+++ b/Assets/Project/Scenes/TutorialScene.unity
@@ -50,12 +50,11 @@ LightmapSettings:
     m_BounceScale: 1
     m_IndirectOutputScale: 1
     m_AlbedoBoost: 1
-    m_TemporalCoherenceThreshold: 1
     m_EnvironmentLightingMode: 0
     m_EnableBakedLightmaps: 0
     m_EnableRealtimeLightmaps: 0
   m_LightmapEditorSettings:
-    serializedVersion: 10
+    serializedVersion: 12
     m_Resolution: 2
     m_BakeResolution: 40
     m_AtlasSize: 1024
@@ -63,6 +62,7 @@ LightmapSettings:
     m_AOMaxDistance: 1
     m_CompAOExponent: 1
     m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
     m_Padding: 2
     m_LightmapParameters: {fileID: 0}
     m_LightmapsBakeMode: 1
@@ -77,10 +77,16 @@ LightmapSettings:
     m_PVRDirectSampleCount: 32
     m_PVRSampleCount: 500
     m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 500
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 2
+    m_PVRDenoiserTypeDirect: 0
+    m_PVRDenoiserTypeIndirect: 0
+    m_PVRDenoiserTypeAO: 0
     m_PVRFilterTypeDirect: 0
     m_PVRFilterTypeIndirect: 0
     m_PVRFilterTypeAO: 0
-    m_PVRFilteringMode: 1
+    m_PVREnvironmentMIS: 0
     m_PVRCulling: 1
     m_PVRFilteringGaussRadiusDirect: 1
     m_PVRFilteringGaussRadiusIndirect: 5
@@ -89,6 +95,7 @@ LightmapSettings:
     m_PVRFilteringAtrousPositionSigmaIndirect: 2
     m_PVRFilteringAtrousPositionSigmaAO: 1
     m_ShowResolutionOverlay: 1
+    m_ExportTrainingData: 0
   m_LightingDataAsset: {fileID: 0}
   m_UseShadowmask: 1
 --- !u!196 &4
@@ -116,9 +123,10 @@ NavMeshSettings:
 --- !u!1 &1043785727
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 1043785730}
   - component: {fileID: 1043785729}
@@ -133,8 +141,9 @@ GameObject:
 --- !u!114 &1043785728
 MonoBehaviour:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1043785727}
   m_Enabled: 1
   m_EditorHideFlags: 0
@@ -151,8 +160,9 @@ MonoBehaviour:
 --- !u!114 &1043785729
 MonoBehaviour:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1043785727}
   m_Enabled: 1
   m_EditorHideFlags: 0
@@ -165,8 +175,9 @@ MonoBehaviour:
 --- !u!4 &1043785730
 Transform:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1043785727}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -178,9 +189,10 @@ Transform:
 --- !u!1 &1427207862
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 1427207866}
   - component: {fileID: 1427207865}
@@ -196,8 +208,9 @@ GameObject:
 --- !u!114 &1427207863
 MonoBehaviour:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1427207862}
   m_Enabled: 1
   m_EditorHideFlags: 0
@@ -212,8 +225,9 @@ MonoBehaviour:
 --- !u!114 &1427207864
 MonoBehaviour:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1427207862}
   m_Enabled: 1
   m_EditorHideFlags: 0
@@ -233,8 +247,9 @@ MonoBehaviour:
 --- !u!223 &1427207865
 Canvas:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1427207862}
   m_Enabled: 1
   serializedVersion: 3
@@ -253,8 +268,9 @@ Canvas:
 --- !u!224 &1427207866
 RectTransform:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1427207862}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -272,9 +288,10 @@ RectTransform:
 --- !u!1 &1482979020
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 1482979021}
   - component: {fileID: 1482979023}
@@ -289,8 +306,9 @@ GameObject:
 --- !u!224 &1482979021
 RectTransform:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1482979020}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -307,12 +325,13 @@ RectTransform:
 --- !u!114 &1482979022
 MonoBehaviour:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1482979020}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: 6095efb3f7c9740c28c449abd9d848b0, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
@@ -325,30 +344,34 @@ MonoBehaviour:
       Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_FontData:
     m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
-    m_FontSize: 30
+    m_FontSize: 14
     m_FontStyle: 0
-    m_BestFit: 0
-    m_MinSize: 0
+    m_BestFit: 1
+    m_MinSize: 10
     m_MaxSize: 40
-    m_Alignment: 4
+    m_Alignment: 3
     m_AlignByGeometry: 0
     m_RichText: 1
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: "\u30C1\u30E5\u30FC\u30C8\u30EA\u30A2\u30EB"
+  m_Text: "\u3042\u305D\u3073\u304B\u305F"
+  _textIndex: 15
 --- !u!222 &1482979023
 CanvasRenderer:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1482979020}
+  m_CullTransparentMesh: 0
 --- !u!1 &1737142355
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 1737142359}
   - component: {fileID: 1737142358}
@@ -364,27 +387,36 @@ GameObject:
 --- !u!81 &1737142356
 AudioListener:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1737142355}
   m_Enabled: 1
 --- !u!124 &1737142357
 Behaviour:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1737142355}
   m_Enabled: 1
 --- !u!20 &1737142358
 Camera:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1737142355}
   m_Enabled: 1
   serializedVersion: 2
   m_ClearFlags: 1
   m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_FocalLength: 50
   m_NormalizedViewPortRect:
     serializedVersion: 2
     x: 0
@@ -414,8 +446,9 @@ Camera:
 --- !u!4 &1737142359
 Transform:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1737142355}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: -10}

--- a/Assets/Project/Scenes/TutorialScene.unity
+++ b/Assets/Project/Scenes/TutorialScene.unity
@@ -349,13 +349,13 @@ MonoBehaviour:
     m_BestFit: 1
     m_MinSize: 10
     m_MaxSize: 40
-    m_Alignment: 3
+    m_Alignment: 4
     m_AlignByGeometry: 0
     m_RichText: 1
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: "\u3042\u305D\u3073\u304B\u305F"
+  m_Text: Tutorial
   _textIndex: 15
 --- !u!222 &1482979023
 CanvasRenderer:

--- a/Assets/Project/Scripts/GamePlayScene/GamePlayDirector.cs
+++ b/Assets/Project/Scripts/GamePlayScene/GamePlayDirector.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using Project.Scripts.Utils.Definitions;
 using Project.Scripts.GamePlayScene.Panel;
 using Project.Scripts.Utils.PlayerPrefsUtils;
+using Project.Scripts.Utils.TextUtils;
 using UnityEngine;
 using UnityEngine.Networking;
 using UnityEngine.SceneManagement;
@@ -14,10 +15,7 @@ namespace Project.Scripts.GamePlayScene
     {
         private const string RESULT_WINDOW_NAME = "ResultWindow";
         private const string RESULT_NAME = "Result";
-        private const string SUCCESS_TEXT = "成功！";
-        private const string FAILURE_TEXT = "失敗！";
         private const string WARNING_NAME = "Warning";
-        private const string WARNING_TEXT = "アプリが\nバックグラウンドに\n移動しました";
         private const string STAGE_NUMBER_TEXT_NAME = "StageNumberText";
 
         public delegate void ChangeAction();
@@ -93,7 +91,6 @@ namespace Project.Scripts.GamePlayScene
 
             _resultText = _resultWindow.transform.Find(RESULT_NAME).gameObject;
             _warningText = _resultWindow.transform.Find(WARNING_NAME).gameObject;
-            _warningText.GetComponent<Text>().text = WARNING_TEXT;
 
             _stageNumberText = GameObject.Find(STAGE_NUMBER_TEXT_NAME);
 
@@ -228,7 +225,7 @@ namespace Project.Scripts.GamePlayScene
             if (OnSucceed != null) OnSucceed();
             EndProcess();
             _successAudioSource.Play();
-            _resultText.GetComponent<Text>().text = SUCCESS_TEXT;
+            _resultText.GetComponent<Text>().text = LanguageUtility.GetText(ETextIndex.GameSuccess);
             var ss = StageStatus.Get(stageId);
             // クリア済みにする
             ss.ClearStage(stageId);
@@ -243,8 +240,8 @@ namespace Project.Scripts.GamePlayScene
         {
             if (OnFail != null) OnFail();
             EndProcess();
+            _resultText.GetComponent<Text>().text = LanguageUtility.GetText(ETextIndex.GameFailure);
             _failureAudioSource.Play();
-            _resultText.GetComponent<Text>().text = FAILURE_TEXT;
             // 失敗回数をインクリメント
             var ss = StageStatus.Get(stageId);
             ss.IncFailureNum(stageId);

--- a/Assets/Project/Scripts/GamePlayScene/GamePlayDirector.cs
+++ b/Assets/Project/Scripts/GamePlayScene/GamePlayDirector.cs
@@ -2,8 +2,8 @@
 using System.Linq;
 using Project.Scripts.Utils.Definitions;
 using Project.Scripts.GamePlayScene.Panel;
+using Project.Scripts.UIComponents;
 using Project.Scripts.Utils.PlayerPrefsUtils;
-using Project.Scripts.Utils.TextUtils;
 using UnityEngine;
 using UnityEngine.Networking;
 using UnityEngine.SceneManagement;
@@ -225,7 +225,7 @@ namespace Project.Scripts.GamePlayScene
             if (OnSucceed != null) OnSucceed();
             EndProcess();
             _successAudioSource.Play();
-            _resultText.GetComponent<Text>().text = LanguageUtility.GetText(ETextIndex.GameSuccess);
+            _resultText.GetComponent<MultiLanguageText>().TextIndex = ETextIndex.GameSuccess;
             var ss = StageStatus.Get(stageId);
             // クリア済みにする
             ss.ClearStage(stageId);
@@ -240,7 +240,7 @@ namespace Project.Scripts.GamePlayScene
         {
             if (OnFail != null) OnFail();
             EndProcess();
-            _resultText.GetComponent<Text>().text = LanguageUtility.GetText(ETextIndex.GameFailure);
+            _resultText.GetComponent<MultiLanguageText>().TextIndex = ETextIndex.GameFailure;
             _failureAudioSource.Play();
             // 失敗回数をインクリメント
             var ss = StageStatus.Get(stageId);

--- a/Assets/Project/Scripts/RecordScene/RecordDirector.cs
+++ b/Assets/Project/Scripts/RecordScene/RecordDirector.cs
@@ -17,8 +17,6 @@ namespace Project.Scripts.RecordScene
 
         [SerializeField] private GameObject _successLinePrefab;
 
-        private readonly Dictionary<EStageLevel, GameObject> _levelText = new Dictionary<EStageLevel, GameObject>();
-
         private readonly Dictionary<EStageLevel, GameObject> _percentageText = new Dictionary<EStageLevel, GameObject>();
 
         private readonly Dictionary<EStageLevel, GameObject> _graphArea = new Dictionary<EStageLevel, GameObject>();
@@ -80,8 +78,6 @@ namespace Project.Scripts.RecordScene
         {
             // GameObject の準備
             GetGameObjects(stageLevel);
-            // タイトルの変更
-            _levelText[stageLevel].GetComponent<Text>().text = StageInfo.LevelName[stageLevel];
             // 成功割合の描画
             DrawPercentage(stageLevel);
             // 棒グラフの描画
@@ -98,9 +94,6 @@ namespace Project.Scripts.RecordScene
         {
             // Canvas -> SnapScrollView -> Viewport -> Content -> ${stageLevel} を取得
             var level = GameObject.Find(stageLevel.ToString()).transform;
-
-            // ${stageLevel} -> Level を取得
-            _levelText.Add(stageLevel, level.Find("Level").gameObject);
             // ${stageLevel} -> Percentage を取得
             _percentageText.Add(stageLevel, level.Find("Percentage").gameObject);
             // ${stageLevel} -> GraphArea を取得

--- a/Assets/Project/Scripts/StageSelectScene/StageSelectDirector.cs
+++ b/Assets/Project/Scripts/StageSelectScene/StageSelectDirector.cs
@@ -43,19 +43,8 @@ namespace Project.Scripts.StageSelectScene
         private void Draw()
         {
             foreach (EStageLevel stageLevel in Enum.GetValues(typeof(EStageLevel))) {
-                UpdateText(stageLevel);
                 MakeButtons(stageLevel);
             }
-        }
-
-        /// <summary>
-        /// テキストを更新する
-        /// </summary>
-        /// <param name="stageLevel"> 変更するテキストの難易度 </param>
-        private static void UpdateText(EStageLevel stageLevel)
-        {
-            var text = GameObject.Find("Canvas/SnapScrollView/Viewport/Content/" + stageLevel + "/Level").GetComponent<Text>();
-            text.text = StageInfo.LevelName[stageLevel];
         }
 
         /// <summary>

--- a/Assets/Project/Scripts/Utils/Definitions/StageDefinitions.cs
+++ b/Assets/Project/Scripts/Utils/Definitions/StageDefinitions.cs
@@ -38,18 +38,6 @@ namespace Project.Scripts.Utils.Definitions
         };
 
         /// <summary>
-        /// 難易度ごとに固有の難易度名
-        /// </summary>
-        /// TODO: 今後，多言語対応に組み込む
-        public static readonly Dictionary<EStageLevel, string> LevelName = new Dictionary<EStageLevel, string>()
-        {
-            {EStageLevel.Easy, "簡単"},
-            {EStageLevel.Normal, "普通"},
-            {EStageLevel.Hard, "ムズイ"},
-            {EStageLevel.VeryHard, "激ムズ"}
-        };
-
-        /// <summary>
         /// 難易度ごとに固有のボタン色
         /// </summary>
         /// TODO: 今後，インスペクタから変更できるようにする

--- a/Assets/Project/Scripts/Utils/Definitions/TextDefinitions.cs
+++ b/Assets/Project/Scripts/Utils/Definitions/TextDefinitions.cs
@@ -15,10 +15,10 @@ namespace Project.Scripts.Utils.Definitions
         GameWarning,     // ゲーム中にアプリを閉じた時の注意
         LanguageJapanese,   // 日本語
         LanguageEnglish,    // 英語
-        StageFirst,      // ステージ1
-        StageSecond,     // ステージ2
-        StageThird,      // ステージ3
-        StageFourth,     // ステージ4
+        LevelFirst,      // レベル1
+        LevelSecond,     // レベル2
+        LevelThird,      // レベル3
+        LevelFourth,     // レベル4
         Turorial,        // チュートリアル
         GameTweet,       // ゲーム結果のツイート
     }

--- a/Assets/Project/Scripts/Utils/Definitions/TextDefinitions.cs
+++ b/Assets/Project/Scripts/Utils/Definitions/TextDefinitions.cs
@@ -4,9 +4,21 @@ namespace Project.Scripts.Utils.Definitions
     /// 多言語対応するテキスト
     /// </summary>
     public enum ETextIndex {
-        Success,   // 成功
-        Failed,    // 失敗
-        Config,    // 設定
-        Retry,     // リトライ
+        Config,          // 設定
+        ConfigReset,     // リセット
+        ConfigVibration, // 振動
+        ConfigVolume,    // 音量
+        GameFailure,     // 失敗
+        GameSuccess,     // 成功
+        GameResult,      // 結果
+        GameRetry,       // リトライ
+        GameWarning,     // ゲーム中にアプリを閉じた時の注意
+        LanguageJapanese,   // 日本語
+        LanguageEnglish,    // 英語
+        StageFirst,      // ステージ1
+        StageSecond,     // ステージ2
+        StageThird,      // ステージ3
+        StageFourth,     // ステージ4 
+        Turorial,        // チュートリアル
     }
 }

--- a/Assets/Project/Scripts/Utils/Definitions/TextDefinitions.cs
+++ b/Assets/Project/Scripts/Utils/Definitions/TextDefinitions.cs
@@ -18,7 +18,7 @@ namespace Project.Scripts.Utils.Definitions
         StageFirst,      // ステージ1
         StageSecond,     // ステージ2
         StageThird,      // ステージ3
-        StageFourth,     // ステージ4 
+        StageFourth,     // ステージ4
         Turorial,        // チュートリアル
     }
 }

--- a/Assets/Project/Scripts/Utils/Definitions/TextDefinitions.cs
+++ b/Assets/Project/Scripts/Utils/Definitions/TextDefinitions.cs
@@ -20,5 +20,6 @@ namespace Project.Scripts.Utils.Definitions
         StageThird,      // ステージ3
         StageFourth,     // ステージ4
         Turorial,        // チュートリアル
+        GameTweet,       // ゲーム結果のツイート
     }
 }


### PR DESCRIPTION
## 対象イシュー
Close #170

## 概要
- 現在使われているテキストを多言語対応させる(MultiLanguageText.csを使って実装する)
- 結果画面の`戻る`ボタンと、ステージ選択画面の`ステージxへ`の2箇所については、たぶん文字のままリリースされることは無いので(強く反対するので)、多言語対応させていません。
- UIについてはどうせ後から配置とか色々変わるけど、現時点で見やすいように多少整列させました。

## 技術的な内容
- GUIで設定した部分がほとんど。
- スクリプトからテキストを設定していた部分(結果画面の成功/失敗など)は、`translation.csv`テキストのindexを指定して参照する。

## キャプチャ

