### PR TITLE
撃ち抜く銃弾の銃跡をパネルに追従させる

### DIFF
--- a/Assets/Project/Prefabs/GamePlayScene/Bullet/Cartridge/NormalCartridgePrefab.prefab
+++ b/Assets/Project/Prefabs/GamePlayScene/Bullet/Cartridge/NormalCartridgePrefab.prefab
@@ -13,7 +13,7 @@ GameObject:
   - component: {fileID: 114617676760384634}
   - component: {fileID: 8667623524509177951}
   - component: {fileID: 5685266870691338383}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: NormalCartridgePrefab
   m_TagString: Bullet
   m_Icon: {fileID: 0}

--- a/Assets/Project/Prefabs/GamePlayScene/Bullet/Cartridge/TurnCartridgePrefab.prefab
+++ b/Assets/Project/Prefabs/GamePlayScene/Bullet/Cartridge/TurnCartridgePrefab.prefab
@@ -13,7 +13,7 @@ GameObject:
   - component: {fileID: 114569484378481306}
   - component: {fileID: -1925789541212344210}
   - component: {fileID: 1937630506875268259}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: TurnCartridgePrefab
   m_TagString: Bullet
   m_Icon: {fileID: 0}

--- a/Assets/Project/Prefabs/GamePlayScene/Bullet/Hole/NormalHolePrefab.prefab
+++ b/Assets/Project/Prefabs/GamePlayScene/Bullet/Hole/NormalHolePrefab.prefab
@@ -13,7 +13,7 @@ GameObject:
   - component: {fileID: 114564193246404582}
   - component: {fileID: -2112501252169391278}
   - component: {fileID: 7432704729882775510}
-  m_Layer: 0
+  m_Layer: 10
   m_Name: NormalHolePrefab
   m_TagString: Bullet
   m_Icon: {fileID: 0}

--- a/Assets/Project/Prefabs/GamePlayScene/Bullet/Hole/NormalHolePrefab.prefab
+++ b/Assets/Project/Prefabs/GamePlayScene/Bullet/Hole/NormalHolePrefab.prefab
@@ -94,6 +94,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5ac7c74b850c747e2ba6890c1e0484d5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  speed: 0.05
 --- !u!61 &-2112501252169391278
 BoxCollider2D:
   m_ObjectHideFlags: 0

--- a/Assets/Project/Prefabs/GamePlayScene/Bullet/Hole/aimingHolePrefab.prefab
+++ b/Assets/Project/Prefabs/GamePlayScene/Bullet/Hole/aimingHolePrefab.prefab
@@ -13,7 +13,7 @@ GameObject:
   - component: {fileID: 114936374060992412}
   - component: {fileID: 1768844315502914671}
   - component: {fileID: -8451264784571383085}
-  m_Layer: 0
+  m_Layer: 10
   m_Name: aimingHolePrefab
   m_TagString: Bullet
   m_Icon: {fileID: 0}

--- a/Assets/Project/Prefabs/GamePlayScene/Bullet/Hole/aimingHolePrefab.prefab
+++ b/Assets/Project/Prefabs/GamePlayScene/Bullet/Hole/aimingHolePrefab.prefab
@@ -94,6 +94,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 15e93bb1090ee40df9c1955892d209e2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  speed: 0.05
 --- !u!61 &1768844315502914671
 BoxCollider2D:
   m_ObjectHideFlags: 0

--- a/Assets/Project/Prefabs/GamePlayScene/Panel/dynamicDummyPanelPrefab.prefab
+++ b/Assets/Project/Prefabs/GamePlayScene/Panel/dynamicDummyPanelPrefab.prefab
@@ -15,7 +15,7 @@ GameObject:
   - component: {fileID: -7919264550677916442}
   m_Layer: 0
   m_Name: dynamicDummyPanelPrefab
-  m_TagString: Untagged
+  m_TagString: DummyPanel
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/Project/Prefabs/GamePlayScene/Panel/dynamicDummyPanelPrefab.prefab
+++ b/Assets/Project/Prefabs/GamePlayScene/Panel/dynamicDummyPanelPrefab.prefab
@@ -13,7 +13,7 @@ GameObject:
   - component: {fileID: 114989368649593642}
   - component: {fileID: -2211765263296871505}
   - component: {fileID: -7919264550677916442}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: dynamicDummyPanelPrefab
   m_TagString: DummyPanel
   m_Icon: {fileID: 0}

--- a/Assets/Project/Prefabs/GamePlayScene/Panel/staticDummyPanelPrefab.prefab
+++ b/Assets/Project/Prefabs/GamePlayScene/Panel/staticDummyPanelPrefab.prefab
@@ -13,7 +13,7 @@ GameObject:
   - component: {fileID: 114688854412061546}
   m_Layer: 0
   m_Name: staticDummyPanelPrefab
-  m_TagString: Untagged
+  m_TagString: DummyPanel
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/Project/Prefabs/GamePlayScene/Panel/staticDummyPanelPrefab.prefab
+++ b/Assets/Project/Prefabs/GamePlayScene/Panel/staticDummyPanelPrefab.prefab
@@ -11,7 +11,7 @@ GameObject:
   - component: {fileID: 4470369291969820}
   - component: {fileID: 212957416217724866}
   - component: {fileID: 114688854412061546}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: staticDummyPanelPrefab
   m_TagString: DummyPanel
   m_Icon: {fileID: 0}

--- a/Assets/Project/Prefabs/GamePlayScene/Tile/normalTilePrefab.prefab
+++ b/Assets/Project/Prefabs/GamePlayScene/Tile/normalTilePrefab.prefab
@@ -1,22 +1,12 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1001 &100100000
-Prefab:
-  m_ObjectHideFlags: 1
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications: []
-    m_RemovedComponents: []
-  m_ParentPrefab: {fileID: 0}
-  m_RootGameObject: {fileID: 1202584627454472}
-  m_IsPrefabParent: 1
 --- !u!1 &1202584627454472
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 5
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 4482315734691428}
   - component: {fileID: 212720884470728028}
@@ -30,9 +20,10 @@ GameObject:
   m_IsActive: 1
 --- !u!4 &4482315734691428
 Transform:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1202584627454472}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -41,26 +32,12 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &114202185148520404
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1202584627454472}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f280afc13a4e74a17b01d252cc4c56a3, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  rightTile: {fileID: 0}
-  leftTile: {fileID: 0}
-  upperTile: {fileID: 0}
-  lowerTile: {fileID: 0}
 --- !u!212 &212720884470728028
 SpriteRenderer:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1202584627454472}
   m_Enabled: 1
   m_CastShadows: 0
@@ -70,6 +47,7 @@ SpriteRenderer:
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
   m_RenderingLayerMask: 4294967295
+  m_RendererPriority: 0
   m_Materials:
   - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
   m_StaticBatchInfo:
@@ -101,3 +79,20 @@ SpriteRenderer:
   m_SpriteTileMode: 0
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!114 &114202185148520404
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1202584627454472}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f280afc13a4e74a17b01d252cc4c56a3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _rightTile: {fileID: 0}
+  _leftTile: {fileID: 0}
+  _upperTile: {fileID: 0}
+  _lowerTile: {fileID: 0}

--- a/Assets/Project/Prefabs/GamePlayScene/Tile/normalTilePrefab.prefab
+++ b/Assets/Project/Prefabs/GamePlayScene/Tile/normalTilePrefab.prefab
@@ -21,7 +21,7 @@ GameObject:
   - component: {fileID: 4482315734691428}
   - component: {fileID: 212720884470728028}
   - component: {fileID: 114202185148520404}
-  m_Layer: 0
+  m_Layer: 12
   m_Name: normalTilePrefab
   m_TagString: Tile
   m_Icon: {fileID: 0}

--- a/Assets/Project/Prefabs/GamePlayScene/Tile/numberTile1Prefab.prefab
+++ b/Assets/Project/Prefabs/GamePlayScene/Tile/numberTile1Prefab.prefab
@@ -1,22 +1,12 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1001 &100100000
-Prefab:
-  m_ObjectHideFlags: 1
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications: []
-    m_RemovedComponents: []
-  m_ParentPrefab: {fileID: 0}
-  m_RootGameObject: {fileID: 1720766100627462}
-  m_IsPrefabParent: 1
 --- !u!1 &1720766100627462
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 5
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 4367601904586250}
   - component: {fileID: 212814163170591972}
@@ -30,9 +20,10 @@ GameObject:
   m_IsActive: 1
 --- !u!4 &4367601904586250
 Transform:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1720766100627462}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -41,26 +32,12 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &114598903664325950
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1720766100627462}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6728fbddefa994c0c8c311b28795f4ba, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  rightTile: {fileID: 0}
-  leftTile: {fileID: 0}
-  upperTile: {fileID: 0}
-  lowerTile: {fileID: 0}
 --- !u!212 &212814163170591972
 SpriteRenderer:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1720766100627462}
   m_Enabled: 1
   m_CastShadows: 0
@@ -70,6 +47,7 @@ SpriteRenderer:
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
   m_RenderingLayerMask: 4294967295
+  m_RendererPriority: 0
   m_Materials:
   - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
   m_StaticBatchInfo:
@@ -101,3 +79,20 @@ SpriteRenderer:
   m_SpriteTileMode: 0
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!114 &114598903664325950
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1720766100627462}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6728fbddefa994c0c8c311b28795f4ba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _rightTile: {fileID: 0}
+  _leftTile: {fileID: 0}
+  _upperTile: {fileID: 0}
+  _lowerTile: {fileID: 0}

--- a/Assets/Project/Prefabs/GamePlayScene/Tile/numberTile1Prefab.prefab
+++ b/Assets/Project/Prefabs/GamePlayScene/Tile/numberTile1Prefab.prefab
@@ -21,7 +21,7 @@ GameObject:
   - component: {fileID: 4367601904586250}
   - component: {fileID: 212814163170591972}
   - component: {fileID: 114598903664325950}
-  m_Layer: 0
+  m_Layer: 12
   m_Name: numberTile1Prefab
   m_TagString: Tile
   m_Icon: {fileID: 0}

--- a/Assets/Project/Prefabs/GamePlayScene/Tile/numberTile2Prefab.prefab
+++ b/Assets/Project/Prefabs/GamePlayScene/Tile/numberTile2Prefab.prefab
@@ -21,7 +21,7 @@ GameObject:
   - component: {fileID: 4126715964356438}
   - component: {fileID: 212293275318837778}
   - component: {fileID: 114410099591546762}
-  m_Layer: 0
+  m_Layer: 12
   m_Name: numberTile2Prefab
   m_TagString: Tile
   m_Icon: {fileID: 0}

--- a/Assets/Project/Prefabs/GamePlayScene/Tile/numberTile2Prefab.prefab
+++ b/Assets/Project/Prefabs/GamePlayScene/Tile/numberTile2Prefab.prefab
@@ -1,22 +1,12 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1001 &100100000
-Prefab:
-  m_ObjectHideFlags: 1
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications: []
-    m_RemovedComponents: []
-  m_ParentPrefab: {fileID: 0}
-  m_RootGameObject: {fileID: 1728207391172570}
-  m_IsPrefabParent: 1
 --- !u!1 &1728207391172570
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 5
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 4126715964356438}
   - component: {fileID: 212293275318837778}
@@ -30,9 +20,10 @@ GameObject:
   m_IsActive: 1
 --- !u!4 &4126715964356438
 Transform:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1728207391172570}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -41,26 +32,12 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &114410099591546762
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1728207391172570}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6728fbddefa994c0c8c311b28795f4ba, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  rightTile: {fileID: 0}
-  leftTile: {fileID: 0}
-  upperTile: {fileID: 0}
-  lowerTile: {fileID: 0}
 --- !u!212 &212293275318837778
 SpriteRenderer:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1728207391172570}
   m_Enabled: 1
   m_CastShadows: 0
@@ -70,6 +47,7 @@ SpriteRenderer:
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
   m_RenderingLayerMask: 4294967295
+  m_RendererPriority: 0
   m_Materials:
   - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
   m_StaticBatchInfo:
@@ -101,3 +79,20 @@ SpriteRenderer:
   m_SpriteTileMode: 0
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!114 &114410099591546762
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1728207391172570}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6728fbddefa994c0c8c311b28795f4ba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _rightTile: {fileID: 0}
+  _leftTile: {fileID: 0}
+  _upperTile: {fileID: 0}
+  _lowerTile: {fileID: 0}

--- a/Assets/Project/Prefabs/GamePlayScene/Tile/numberTile3Prefab.prefab
+++ b/Assets/Project/Prefabs/GamePlayScene/Tile/numberTile3Prefab.prefab
@@ -1,22 +1,12 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1001 &100100000
-Prefab:
-  m_ObjectHideFlags: 1
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications: []
-    m_RemovedComponents: []
-  m_ParentPrefab: {fileID: 0}
-  m_RootGameObject: {fileID: 1479016069720960}
-  m_IsPrefabParent: 1
 --- !u!1 &1479016069720960
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 5
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 4492524440120346}
   - component: {fileID: 212742855564022360}
@@ -30,9 +20,10 @@ GameObject:
   m_IsActive: 1
 --- !u!4 &4492524440120346
 Transform:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1479016069720960}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -41,26 +32,12 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &114924839462849950
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1479016069720960}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6728fbddefa994c0c8c311b28795f4ba, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  rightTile: {fileID: 0}
-  leftTile: {fileID: 0}
-  upperTile: {fileID: 0}
-  lowerTile: {fileID: 0}
 --- !u!212 &212742855564022360
 SpriteRenderer:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1479016069720960}
   m_Enabled: 1
   m_CastShadows: 0
@@ -70,6 +47,7 @@ SpriteRenderer:
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
   m_RenderingLayerMask: 4294967295
+  m_RendererPriority: 0
   m_Materials:
   - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
   m_StaticBatchInfo:
@@ -101,3 +79,20 @@ SpriteRenderer:
   m_SpriteTileMode: 0
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!114 &114924839462849950
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1479016069720960}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6728fbddefa994c0c8c311b28795f4ba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _rightTile: {fileID: 0}
+  _leftTile: {fileID: 0}
+  _upperTile: {fileID: 0}
+  _lowerTile: {fileID: 0}

--- a/Assets/Project/Prefabs/GamePlayScene/Tile/numberTile3Prefab.prefab
+++ b/Assets/Project/Prefabs/GamePlayScene/Tile/numberTile3Prefab.prefab
@@ -21,7 +21,7 @@ GameObject:
   - component: {fileID: 4492524440120346}
   - component: {fileID: 212742855564022360}
   - component: {fileID: 114924839462849950}
-  m_Layer: 0
+  m_Layer: 12
   m_Name: numberTile3Prefab
   m_TagString: Tile
   m_Icon: {fileID: 0}

--- a/Assets/Project/Prefabs/GamePlayScene/Tile/numberTile4Prefab.prefab
+++ b/Assets/Project/Prefabs/GamePlayScene/Tile/numberTile4Prefab.prefab
@@ -1,22 +1,12 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1001 &100100000
-Prefab:
-  m_ObjectHideFlags: 1
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications: []
-    m_RemovedComponents: []
-  m_ParentPrefab: {fileID: 0}
-  m_RootGameObject: {fileID: 1621355552667394}
-  m_IsPrefabParent: 1
 --- !u!1 &1621355552667394
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 5
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 4630794031637240}
   - component: {fileID: 212459062098516222}
@@ -30,9 +20,10 @@ GameObject:
   m_IsActive: 1
 --- !u!4 &4630794031637240
 Transform:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1621355552667394}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -41,26 +32,12 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &114832025811149342
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1621355552667394}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6728fbddefa994c0c8c311b28795f4ba, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  rightTile: {fileID: 0}
-  leftTile: {fileID: 0}
-  upperTile: {fileID: 0}
-  lowerTile: {fileID: 0}
 --- !u!212 &212459062098516222
 SpriteRenderer:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1621355552667394}
   m_Enabled: 1
   m_CastShadows: 0
@@ -70,6 +47,7 @@ SpriteRenderer:
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
   m_RenderingLayerMask: 4294967295
+  m_RendererPriority: 0
   m_Materials:
   - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
   m_StaticBatchInfo:
@@ -101,3 +79,20 @@ SpriteRenderer:
   m_SpriteTileMode: 0
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!114 &114832025811149342
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1621355552667394}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6728fbddefa994c0c8c311b28795f4ba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _rightTile: {fileID: 0}
+  _leftTile: {fileID: 0}
+  _upperTile: {fileID: 0}
+  _lowerTile: {fileID: 0}

--- a/Assets/Project/Prefabs/GamePlayScene/Tile/numberTile4Prefab.prefab
+++ b/Assets/Project/Prefabs/GamePlayScene/Tile/numberTile4Prefab.prefab
@@ -21,7 +21,7 @@ GameObject:
   - component: {fileID: 4630794031637240}
   - component: {fileID: 212459062098516222}
   - component: {fileID: 114832025811149342}
-  m_Layer: 0
+  m_Layer: 12
   m_Name: numberTile4Prefab
   m_TagString: Tile
   m_Icon: {fileID: 0}

--- a/Assets/Project/Prefabs/GamePlayScene/Tile/numberTile5Prefab.prefab
+++ b/Assets/Project/Prefabs/GamePlayScene/Tile/numberTile5Prefab.prefab
@@ -1,22 +1,12 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1001 &100100000
-Prefab:
-  m_ObjectHideFlags: 1
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications: []
-    m_RemovedComponents: []
-  m_ParentPrefab: {fileID: 0}
-  m_RootGameObject: {fileID: 1033863517126588}
-  m_IsPrefabParent: 1
 --- !u!1 &1033863517126588
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 5
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 4182273156105970}
   - component: {fileID: 212110677941647206}
@@ -30,9 +20,10 @@ GameObject:
   m_IsActive: 1
 --- !u!4 &4182273156105970
 Transform:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1033863517126588}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -41,26 +32,12 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &114488741242063928
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1033863517126588}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6728fbddefa994c0c8c311b28795f4ba, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  rightTile: {fileID: 0}
-  leftTile: {fileID: 0}
-  upperTile: {fileID: 0}
-  lowerTile: {fileID: 0}
 --- !u!212 &212110677941647206
 SpriteRenderer:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1033863517126588}
   m_Enabled: 1
   m_CastShadows: 0
@@ -70,6 +47,7 @@ SpriteRenderer:
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
   m_RenderingLayerMask: 4294967295
+  m_RendererPriority: 0
   m_Materials:
   - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
   m_StaticBatchInfo:
@@ -101,3 +79,20 @@ SpriteRenderer:
   m_SpriteTileMode: 0
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!114 &114488741242063928
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1033863517126588}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6728fbddefa994c0c8c311b28795f4ba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _rightTile: {fileID: 0}
+  _leftTile: {fileID: 0}
+  _upperTile: {fileID: 0}
+  _lowerTile: {fileID: 0}

--- a/Assets/Project/Prefabs/GamePlayScene/Tile/numberTile5Prefab.prefab
+++ b/Assets/Project/Prefabs/GamePlayScene/Tile/numberTile5Prefab.prefab
@@ -21,7 +21,7 @@ GameObject:
   - component: {fileID: 4182273156105970}
   - component: {fileID: 212110677941647206}
   - component: {fileID: 114488741242063928}
-  m_Layer: 0
+  m_Layer: 12
   m_Name: numberTile5Prefab
   m_TagString: Tile
   m_Icon: {fileID: 0}

--- a/Assets/Project/Prefabs/GamePlayScene/Tile/numberTile6Prefab.prefab
+++ b/Assets/Project/Prefabs/GamePlayScene/Tile/numberTile6Prefab.prefab
@@ -21,7 +21,7 @@ GameObject:
   - component: {fileID: 4380493274482196}
   - component: {fileID: 212562249403175830}
   - component: {fileID: 114447457105615336}
-  m_Layer: 0
+  m_Layer: 12
   m_Name: numberTile6Prefab
   m_TagString: Tile
   m_Icon: {fileID: 0}

--- a/Assets/Project/Prefabs/GamePlayScene/Tile/numberTile6Prefab.prefab
+++ b/Assets/Project/Prefabs/GamePlayScene/Tile/numberTile6Prefab.prefab
@@ -1,22 +1,12 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1001 &100100000
-Prefab:
-  m_ObjectHideFlags: 1
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications: []
-    m_RemovedComponents: []
-  m_ParentPrefab: {fileID: 0}
-  m_RootGameObject: {fileID: 1305301057825576}
-  m_IsPrefabParent: 1
 --- !u!1 &1305301057825576
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 5
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 4380493274482196}
   - component: {fileID: 212562249403175830}
@@ -30,9 +20,10 @@ GameObject:
   m_IsActive: 1
 --- !u!4 &4380493274482196
 Transform:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1305301057825576}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -41,26 +32,12 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &114447457105615336
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1305301057825576}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6728fbddefa994c0c8c311b28795f4ba, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  rightTile: {fileID: 0}
-  leftTile: {fileID: 0}
-  upperTile: {fileID: 0}
-  lowerTile: {fileID: 0}
 --- !u!212 &212562249403175830
 SpriteRenderer:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1305301057825576}
   m_Enabled: 1
   m_CastShadows: 0
@@ -70,6 +47,7 @@ SpriteRenderer:
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
   m_RenderingLayerMask: 4294967295
+  m_RendererPriority: 0
   m_Materials:
   - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
   m_StaticBatchInfo:
@@ -101,3 +79,20 @@ SpriteRenderer:
   m_SpriteTileMode: 0
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!114 &114447457105615336
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1305301057825576}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6728fbddefa994c0c8c311b28795f4ba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _rightTile: {fileID: 0}
+  _leftTile: {fileID: 0}
+  _upperTile: {fileID: 0}
+  _lowerTile: {fileID: 0}

--- a/Assets/Project/Prefabs/GamePlayScene/Tile/numberTile7Prefab.prefab
+++ b/Assets/Project/Prefabs/GamePlayScene/Tile/numberTile7Prefab.prefab
@@ -1,22 +1,12 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1001 &100100000
-Prefab:
-  m_ObjectHideFlags: 1
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications: []
-    m_RemovedComponents: []
-  m_ParentPrefab: {fileID: 0}
-  m_RootGameObject: {fileID: 1001052288116312}
-  m_IsPrefabParent: 1
 --- !u!1 &1001052288116312
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 5
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 4653726665732106}
   - component: {fileID: 212786206854819852}
@@ -30,9 +20,10 @@ GameObject:
   m_IsActive: 1
 --- !u!4 &4653726665732106
 Transform:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1001052288116312}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -41,26 +32,12 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &114235661687624482
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1001052288116312}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6728fbddefa994c0c8c311b28795f4ba, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  rightTile: {fileID: 0}
-  leftTile: {fileID: 0}
-  upperTile: {fileID: 0}
-  lowerTile: {fileID: 0}
 --- !u!212 &212786206854819852
 SpriteRenderer:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1001052288116312}
   m_Enabled: 1
   m_CastShadows: 0
@@ -70,6 +47,7 @@ SpriteRenderer:
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
   m_RenderingLayerMask: 4294967295
+  m_RendererPriority: 0
   m_Materials:
   - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
   m_StaticBatchInfo:
@@ -101,3 +79,20 @@ SpriteRenderer:
   m_SpriteTileMode: 0
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!114 &114235661687624482
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1001052288116312}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6728fbddefa994c0c8c311b28795f4ba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _rightTile: {fileID: 0}
+  _leftTile: {fileID: 0}
+  _upperTile: {fileID: 0}
+  _lowerTile: {fileID: 0}

--- a/Assets/Project/Prefabs/GamePlayScene/Tile/numberTile7Prefab.prefab
+++ b/Assets/Project/Prefabs/GamePlayScene/Tile/numberTile7Prefab.prefab
@@ -21,7 +21,7 @@ GameObject:
   - component: {fileID: 4653726665732106}
   - component: {fileID: 212786206854819852}
   - component: {fileID: 114235661687624482}
-  m_Layer: 0
+  m_Layer: 12
   m_Name: numberTile7Prefab
   m_TagString: Tile
   m_Icon: {fileID: 0}

--- a/Assets/Project/Prefabs/GamePlayScene/Tile/numberTile8Prefab.prefab
+++ b/Assets/Project/Prefabs/GamePlayScene/Tile/numberTile8Prefab.prefab
@@ -1,22 +1,12 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1001 &100100000
-Prefab:
-  m_ObjectHideFlags: 1
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications: []
-    m_RemovedComponents: []
-  m_ParentPrefab: {fileID: 0}
-  m_RootGameObject: {fileID: 1451089964976956}
-  m_IsPrefabParent: 1
 --- !u!1 &1451089964976956
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 5
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 4651481313911568}
   - component: {fileID: 212433506970306086}
@@ -30,9 +20,10 @@ GameObject:
   m_IsActive: 1
 --- !u!4 &4651481313911568
 Transform:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1451089964976956}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -41,26 +32,12 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &114022013442611384
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1451089964976956}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6728fbddefa994c0c8c311b28795f4ba, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  rightTile: {fileID: 0}
-  leftTile: {fileID: 0}
-  upperTile: {fileID: 0}
-  lowerTile: {fileID: 0}
 --- !u!212 &212433506970306086
 SpriteRenderer:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1451089964976956}
   m_Enabled: 1
   m_CastShadows: 0
@@ -70,6 +47,7 @@ SpriteRenderer:
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
   m_RenderingLayerMask: 4294967295
+  m_RendererPriority: 0
   m_Materials:
   - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
   m_StaticBatchInfo:
@@ -101,3 +79,20 @@ SpriteRenderer:
   m_SpriteTileMode: 0
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!114 &114022013442611384
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1451089964976956}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6728fbddefa994c0c8c311b28795f4ba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _rightTile: {fileID: 0}
+  _leftTile: {fileID: 0}
+  _upperTile: {fileID: 0}
+  _lowerTile: {fileID: 0}

--- a/Assets/Project/Prefabs/GamePlayScene/Tile/numberTile8Prefab.prefab
+++ b/Assets/Project/Prefabs/GamePlayScene/Tile/numberTile8Prefab.prefab
@@ -21,7 +21,7 @@ GameObject:
   - component: {fileID: 4651481313911568}
   - component: {fileID: 212433506970306086}
   - component: {fileID: 114022013442611384}
-  m_Layer: 0
+  m_Layer: 12
   m_Name: numberTile8Prefab
   m_TagString: Tile
   m_Icon: {fileID: 0}

--- a/Assets/Project/Prefabs/GamePlayScene/Tile/warpTilePrefab.prefab
+++ b/Assets/Project/Prefabs/GamePlayScene/Tile/warpTilePrefab.prefab
@@ -1,22 +1,12 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1001 &100100000
-Prefab:
-  m_ObjectHideFlags: 1
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications: []
-    m_RemovedComponents: []
-  m_ParentPrefab: {fileID: 0}
-  m_RootGameObject: {fileID: 1341861734510488}
-  m_IsPrefabParent: 1
 --- !u!1 &1341861734510488
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 5
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 4506576226392830}
   - component: {fileID: 212825280248773570}
@@ -30,9 +20,10 @@ GameObject:
   m_IsActive: 1
 --- !u!4 &4506576226392830
 Transform:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1341861734510488}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -41,27 +32,12 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &114818606633156616
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1341861734510488}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f0d67377de4d44f59466b2d4da72ac73, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  rightTile: {fileID: 0}
-  leftTile: {fileID: 0}
-  upperTile: {fileID: 0}
-  lowerTile: {fileID: 0}
-  pairTile: {fileID: 0}
 --- !u!212 &212825280248773570
 SpriteRenderer:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1341861734510488}
   m_Enabled: 1
   m_CastShadows: 0
@@ -71,6 +47,7 @@ SpriteRenderer:
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
   m_RenderingLayerMask: 4294967295
+  m_RendererPriority: 0
   m_Materials:
   - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
   m_StaticBatchInfo:
@@ -102,3 +79,21 @@ SpriteRenderer:
   m_SpriteTileMode: 0
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!114 &114818606633156616
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1341861734510488}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f0d67377de4d44f59466b2d4da72ac73, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _rightTile: {fileID: 0}
+  _leftTile: {fileID: 0}
+  _upperTile: {fileID: 0}
+  _lowerTile: {fileID: 0}
+  _pairTile: {fileID: 0}

--- a/Assets/Project/Prefabs/GamePlayScene/Tile/warpTilePrefab.prefab
+++ b/Assets/Project/Prefabs/GamePlayScene/Tile/warpTilePrefab.prefab
@@ -21,7 +21,7 @@ GameObject:
   - component: {fileID: 4506576226392830}
   - component: {fileID: 212825280248773570}
   - component: {fileID: 114818606633156616}
-  m_Layer: 0
+  m_Layer: 12
   m_Name: warpTilePrefab
   m_TagString: Tile
   m_Icon: {fileID: 0}

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/NormalHoleController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/NormalHoleController.cs
@@ -30,6 +30,8 @@ namespace Project.Scripts.GamePlayScene.Bullet
         protected override void Awake()
         {
             base.Awake();
+            // タイルとパネルの間のレイヤー(Hole)に描画する
+            gameObject.GetComponent<Renderer>().sortingLayerName = SortingLayerName.HOLE;
             transform.localScale = new Vector2(HoleSize.WIDTH / originalWidth, HoleSize.HEIGHT / originalHeight) *
             LOCAL_SCALE;
         }
@@ -104,15 +106,16 @@ namespace Project.Scripts.GamePlayScene.Bullet
         {
             // 銃痕(hole)が出現したフレーム以外では衝突を考えない
             if (transform.position.z < 0) return;
+            // パネルとの衝突
             if (other.gameObject.CompareTag(TagName.NUMBER_PANEL)) {
                 // 数字パネルとの衝突
                 // 衝突したオブジェクトは赤色に変える
                 gameObject.GetComponent<SpriteRenderer>().color = Color.red;
-                gameObject.transform.parent = other.transform;
-            } else if (other.gameObject.CompareTag(TagName.DUMMY_PANEL)) {
-                // ダミーパネルとの衝突
-                gameObject.transform.parent = other.transform;
             }
+            // パネルより手前のレイヤー(BULLET)に描画する
+            gameObject.GetComponent<Renderer>().sortingLayerName = SortingLayerName.BULLET;
+            // holeを衝突したパネルに追従させる
+            gameObject.transform.parent = other.transform;
         }
     }
 }

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/NormalHoleController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/NormalHoleController.cs
@@ -25,7 +25,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
         /// <summary>
         /// 各フレームの透明度の減少量
         /// </summary>
-        private float alphaChange = 1.0f / HOLE_DISPLAYED_FRAMES;
+        private float _alphaChange = 1.0f / HOLE_DISPLAYED_FRAMES;
 
         protected override void Awake()
         {
@@ -62,12 +62,12 @@ namespace Project.Scripts.GamePlayScene.Bullet
             // 奥行き方向に移動させる(見た目の変化はない)
             transform.Translate(Vector3.back * speed, Space.World);
             // 透明度をあげてだんだんと見えなくする
-            gameObject.GetComponent<SpriteRenderer>().color -= new Color(0, 0, 0, alphaChange);
+            gameObject.GetComponent<SpriteRenderer>().color -= new Color(0, 0, 0, _alphaChange);
         }
 
         protected override void OnFail()
         {
-            alphaChange = 0.0f;
+            _alphaChange = 0.0f;
         }
 
         /// <summary>

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/NormalHoleController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/NormalHoleController.cs
@@ -25,7 +25,8 @@ namespace Project.Scripts.GamePlayScene.Bullet
         /// <summary>
         /// 各フレームの透明度の減少量
         /// </summary>
-        protected float alphaChange = 1.0f / HOLE_DISPLAYED_FRAMES;
+        private float alphaChange = 1.0f / HOLE_DISPLAYED_FRAMES;
+
         protected override void Awake()
         {
             base.Awake();

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/NormalHoleController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/NormalHoleController.cs
@@ -11,7 +11,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
         /// <summary>
         /// 表示フレーム数
         /// </summary>
-        private const int HOLE_DISPLAYED_FRAMES = 25;
+        private const int HOLE_DISPLAYED_FRAMES = 100;
 
         /// <summary>
         /// 出現する行
@@ -22,6 +22,10 @@ namespace Project.Scripts.GamePlayScene.Bullet
         /// </summary>
         protected int column;
 
+        /// <summary>
+        /// 各フレームの透明度の減少量
+        /// </summary>
+        protected float alphaChange = 1.0f / HOLE_DISPLAYED_FRAMES;
         protected override void Awake()
         {
             base.Awake();
@@ -54,10 +58,13 @@ namespace Project.Scripts.GamePlayScene.Bullet
         {
             // 奥行き方向に移動させる(見た目の変化はない)
             transform.Translate(Vector3.back * speed, Space.World);
+            // 透明度をあげてだんだんと見えなくする
+            gameObject.GetComponent<SpriteRenderer>().color -= new Color(0, 0, 0, alphaChange);
         }
 
         protected override void OnFail()
         {
+            alphaChange = 0.0f;
         }
 
         /// <summary>
@@ -94,13 +101,19 @@ namespace Project.Scripts.GamePlayScene.Bullet
 
         protected override void OnTriggerEnter2D(Collider2D other)
         {
-            // 数字パネルとの衝突以外は考えない
-            if (!other.gameObject.CompareTag(TagName.NUMBER_PANEL)) return;
             // 銃痕(hole)が出現したフレーム以外では衝突を考えない
             if (transform.position.z < 0) return;
-
-            // 衝突したオブジェクトは赤色に変える
-            gameObject.GetComponent<SpriteRenderer>().color = Color.red;
+            // 数字パネルとの衝突
+            if (other.gameObject.CompareTag(TagName.NUMBER_PANEL))
+            {
+                // 衝突したオブジェクトは赤色に変える
+                gameObject.GetComponent<SpriteRenderer>().color = Color.red;
+                gameObject.transform.parent = other.transform;
+            }
+            else if(other.gameObject.CompareTag(TagName.DUMMY_PANEL))
+            {
+                gameObject.transform.parent = other.transform;
+            }
         }
     }
 }

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/NormalHoleController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/NormalHoleController.cs
@@ -104,14 +104,11 @@ namespace Project.Scripts.GamePlayScene.Bullet
             // 銃痕(hole)が出現したフレーム以外では衝突を考えない
             if (transform.position.z < 0) return;
             // 数字パネルとの衝突
-            if (other.gameObject.CompareTag(TagName.NUMBER_PANEL))
-            {
+            if (other.gameObject.CompareTag(TagName.NUMBER_PANEL)) {
                 // 衝突したオブジェクトは赤色に変える
                 gameObject.GetComponent<SpriteRenderer>().color = Color.red;
                 gameObject.transform.parent = other.transform;
-            }
-            else if(other.gameObject.CompareTag(TagName.DUMMY_PANEL))
-            {
+            } else if (other.gameObject.CompareTag(TagName.DUMMY_PANEL)) {
                 gameObject.transform.parent = other.transform;
             }
         }

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/NormalHoleController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/NormalHoleController.cs
@@ -103,12 +103,13 @@ namespace Project.Scripts.GamePlayScene.Bullet
         {
             // 銃痕(hole)が出現したフレーム以外では衝突を考えない
             if (transform.position.z < 0) return;
-            // 数字パネルとの衝突
             if (other.gameObject.CompareTag(TagName.NUMBER_PANEL)) {
+                // 数字パネルとの衝突
                 // 衝突したオブジェクトは赤色に変える
                 gameObject.GetComponent<SpriteRenderer>().color = Color.red;
                 gameObject.transform.parent = other.transform;
             } else if (other.gameObject.CompareTag(TagName.DUMMY_PANEL)) {
+                // ダミーパネルとの衝突
                 gameObject.transform.parent = other.transform;
             }
         }

--- a/Assets/Project/Scripts/Utils/Definitions/StringDefinitions.cs
+++ b/Assets/Project/Scripts/Utils/Definitions/StringDefinitions.cs
@@ -32,6 +32,7 @@
     {
         public const string TILE = "Tile";
         public const string NUMBER_PANEL = "NumberPanel";
+        public const string DUMMY_PANEL = "DummyPanel";
         public const string BULLET = "Bullet";
         public const string BULLET_WARNING = "BulletWarning";
         public const string GRAPH_UI = "GraphUi";

--- a/ProjectSettings/Physics2DSettings.asset
+++ b/ProjectSettings/Physics2DSettings.asset
@@ -3,7 +3,7 @@
 --- !u!19 &1
 Physics2DSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 3
+  serializedVersion: 4
   m_Gravity: {x: 0, y: -9.81}
   m_DefaultMaterial: {fileID: 0}
   m_VelocityIterations: 8
@@ -19,11 +19,30 @@ Physics2DSettings:
   m_LinearSleepTolerance: 0.01
   m_AngularSleepTolerance: 2
   m_DefaultContactOffset: 0.01
+  m_JobOptions:
+    serializedVersion: 2
+    useMultithreading: 0
+    useConsistencySorting: 0
+    m_InterpolationPosesPerJob: 100
+    m_NewContactsPerJob: 30
+    m_CollideContactsPerJob: 100
+    m_ClearFlagsPerJob: 200
+    m_ClearBodyForcesPerJob: 200
+    m_SyncDiscreteFixturesPerJob: 50
+    m_SyncContinuousFixturesPerJob: 50
+    m_FindNearestContactsPerJob: 100
+    m_UpdateTriggerContactsPerJob: 100
+    m_IslandSolverCostThreshold: 100
+    m_IslandSolverBodyCostScale: 1
+    m_IslandSolverContactCostScale: 10
+    m_IslandSolverJointCostScale: 10
+    m_IslandSolverBodiesPerJob: 50
+    m_IslandSolverContactsPerJob: 50
   m_AutoSimulation: 1
   m_QueriesHitTriggers: 1
   m_QueriesStartInColliders: 1
-  m_ChangeStopsCallbacks: 0
   m_CallbacksOnDisable: 1
+  m_ReuseCollisionCallbacks: 0
   m_AutoSyncTransforms: 1
   m_AlwaysShowColliders: 0
   m_ShowColliderSleep: 1

--- a/ProjectSettings/Physics2DSettings.asset
+++ b/ProjectSettings/Physics2DSettings.asset
@@ -34,4 +34,4 @@ Physics2DSettings:
   m_ColliderAsleepColor: {r: 0.5686275, g: 0.95686275, b: 0.54509807, a: 0.36078432}
   m_ColliderContactColor: {r: 1, g: 0, b: 1, a: 0.6862745}
   m_ColliderAABBColor: {r: 1, g: 1, b: 0, a: 0.2509804}
-  m_LayerCollisionMatrix: ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+  m_LayerCollisionMatrix: ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe6ffffffe9ffffffe9ffffffe6ffffffe0ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -9,6 +9,7 @@ TagManager:
   - BulletWarning
   - Tile
   - GraphUi
+  - DummyPanel
   layers:
   - Default
   - TransparentFX

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -19,10 +19,10 @@ TagManager:
   - 
   - 
   - SpriteGlow
-  - 
-  - 
-  - 
-  - 
+  - Cartridge
+  - Hole
+  - Panel
+  - Tile
   - 
   - 
   - 


### PR DESCRIPTION
## 対象イシュー
Close #78

## 概要
撃ち抜く銃弾がパネル(数字パネル、ダミーパネルのどちらも)と当たり判定が起きたとき、そのパネルの移動に追従するようにする

## 技術的な内容
- 当たり判定時に衝突先のパネルを親とすると、パネルが移動したとき銃痕も移動する
- わかりやすいように、銃痕の表示時間は100フレーム(2.0秒)とし、出現時から消えるまで徐々に透明になっていくようにした。
- 撃ち抜く銃弾が出現するステージ(2-3がわかりやすいと思う)で確認できます。

## 感想
想像よりめっちゃ楽だった。。。

## キャプチャ

