### PR TITLE
画面の回転を禁止する

### DIFF
--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -56,7 +56,7 @@ PlayerSettings:
   displayResolutionDialog: 1
   iosAllowHTTPDownload: 1
   allowedAutorotateToPortrait: 1
-  allowedAutorotateToPortraitUpsideDown: 1
+  allowedAutorotateToPortraitUpsideDown: 0
   allowedAutorotateToLandscapeRight: 0
   allowedAutorotateToLandscapeLeft: 0
   useOSAutorotation: 1


### PR DESCRIPTION
## 対象イシュー
Close #187 

## 概要
画面の横回転は当初に禁止していた。
画面の上下反転は禁止していなかったので、禁止した。

## 参照サイト
http://shiki4020.hatenablog.com/entry/2017/05/06/012222
