### PR TITLE
ゲームクリア時，アニメーション停止

### DIFF
--- a/Assets/Project/Scripts/GamePlayScene/GamePlayDirector.cs
+++ b/Assets/Project/Scripts/GamePlayScene/GamePlayDirector.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using Project.Scripts.Utils.Definitions;
 using Project.Scripts.GamePlayScene.Panel;
 using Project.Scripts.UIComponents;
-using Project.Scripts.Utils.Definitions;
 using Project.Scripts.Utils.PlayerPrefsUtils;
 using UnityEngine;
 using UnityEngine.Networking;

--- a/Assets/Project/Scripts/GamePlayScene/Panel/DynamicPanelController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Panel/DynamicPanelController.cs
@@ -97,7 +97,7 @@ namespace Project.Scripts.GamePlayScene.Panel
         /// <summary>
         /// ゲーム成功時の処理
         /// </summary>
-        private void OnSucceed()
+        protected virtual void OnSucceed()
         {
             GetComponent<FlickGesture>().Flicked -= HandleFlick;
         }
@@ -105,7 +105,7 @@ namespace Project.Scripts.GamePlayScene.Panel
         /// <summary>
         /// ゲーム失敗時の処理
         /// </summary>
-        private void OnFail()
+        protected virtual void OnFail()
         {
             GetComponent<FlickGesture>().Flicked -= HandleFlick;
         }

--- a/Assets/Project/Scripts/GamePlayScene/Panel/LifeNumberPanelController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Panel/LifeNumberPanelController.cs
@@ -42,7 +42,11 @@ namespace Project.Scripts.GamePlayScene.Panel
             if (other.tag == TagName.BULLET && other.gameObject.transform.position.z >= 0) {
                 --_currentLife;
                 if (_currentLife <= 0) {
+                    // 失敗演出
                     _anim.Play(_deadAnimation.name, PlayMode.StopAll);
+
+                    // 自身が破壊された
+                    _dead = true;
 
                     // 失敗状態に移行する
                     gamePlayDirector.Dispatch(GamePlayDirector.EGameState.Failure);

--- a/Assets/Project/Scripts/GamePlayScene/Panel/LifeNumberPanelController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Panel/LifeNumberPanelController.cs
@@ -60,34 +60,5 @@ namespace Project.Scripts.GamePlayScene.Panel
                 }
             }
         }
-
-        /// <summary>
-        /// ゲーム成功時の処理
-        /// </summary>
-        protected override void OnSucceed()
-        {
-            base.OnSucceed();
-            EndProcess();
-        }
-
-        /// <summary>
-        /// ゲーム失敗時の処理
-        /// </summary>
-        protected override void OnFail()
-        {
-            base.OnFail();
-            EndProcess();
-        }
-
-        /// <summary>
-        /// ゲーム終了時の共通処理
-        /// </summary>
-        private void EndProcess()
-        {
-            // 自身が破壊されてない場合には，自身のアニメーションの繰り返しを停止
-            if (!_dead) {
-                _anim.wrapMode = WrapMode.Default;
-            }
-        }
     }
 }

--- a/Assets/Project/Scripts/GamePlayScene/Panel/LifeNumberPanelController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Panel/LifeNumberPanelController.cs
@@ -60,5 +60,34 @@ namespace Project.Scripts.GamePlayScene.Panel
                 }
             }
         }
+
+        /// <summary>
+        /// ゲーム成功時の処理
+        /// </summary>
+        protected override void OnSucceed()
+        {
+            base.OnSucceed();
+            EndProcess();
+        }
+
+        /// <summary>
+        /// ゲーム失敗時の処理
+        /// </summary>
+        protected override void OnFail()
+        {
+            base.OnFail();
+            EndProcess();
+        }
+
+        /// <summary>
+        /// ゲーム終了時の共通処理
+        /// </summary>
+        private void EndProcess()
+        {
+            // 自身が破壊されてない場合には，自身のアニメーションの繰り返しを停止
+            if (!_dead) {
+                _anim.wrapMode = WrapMode.Default;
+            }
+        }
     }
 }

--- a/Assets/Project/Scripts/GamePlayScene/Panel/NumberPanelController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Panel/NumberPanelController.cs
@@ -128,34 +128,5 @@ namespace Project.Scripts.GamePlayScene.Panel
             // 失敗状態に移行する
             gamePlayDirector.Dispatch(GamePlayDirector.EGameState.Failure);
         }
-
-        /// <summary>
-        /// ゲーム成功時の処理
-        /// </summary>
-        protected override void OnSucceed()
-        {
-            base.OnSucceed();
-            EndProcess();
-        }
-
-        /// <summary>
-        /// ゲーム失敗時の処理
-        /// </summary>
-        protected override void OnFail()
-        {
-            base.OnFail();
-            EndProcess();
-        }
-
-        /// <summary>
-        /// ゲーム終了時の共通処理
-        /// </summary>
-        private void EndProcess()
-        {
-            // 自身が破壊されてない場合には，全ての自身のアニメーションを停止
-            if (!_dead) {
-                _anim.Stop();
-            }
-        }
     }
 }

--- a/Assets/Project/Scripts/GamePlayScene/Panel/NumberPanelController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Panel/NumberPanelController.cs
@@ -128,5 +128,34 @@ namespace Project.Scripts.GamePlayScene.Panel
             // 失敗状態に移行する
             gamePlayDirector.Dispatch(GamePlayDirector.EGameState.Failure);
         }
+
+        /// <summary>
+        /// ゲーム成功時の処理
+        /// </summary>
+        protected override void OnSucceed()
+        {
+            base.OnSucceed();
+            EndProcess();
+        }
+
+        /// <summary>
+        /// ゲーム失敗時の処理
+        /// </summary>
+        protected override void OnFail()
+        {
+            base.OnFail();
+            EndProcess();
+        }
+
+        /// <summary>
+        /// ゲーム終了時の共通処理
+        /// </summary>
+        private void EndProcess()
+        {
+            // 自身が破壊されてない場合には，自身のアニメーションの繰り返しを停止
+            if (!_dead) {
+                _anim.wrapMode = WrapMode.Default;
+            }
+        }
     }
 }

--- a/Assets/Project/Scripts/GamePlayScene/Panel/NumberPanelController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Panel/NumberPanelController.cs
@@ -38,6 +38,11 @@ namespace Project.Scripts.GamePlayScene.Panel
 
         protected Animation _anim;
 
+        /// <summary>
+        /// 自身が壊されたかどうか
+        /// </summary>
+        protected bool _dead = false;
+
         protected override void Awake()
         {
             base.Awake();
@@ -117,8 +122,40 @@ namespace Project.Scripts.GamePlayScene.Panel
             // 失敗演出
             _anim.Play(_deadAnimation.name, PlayMode.StopAll);
 
+            // 自身が破壊された
+            _dead = true;
+
             // 失敗状態に移行する
             gamePlayDirector.Dispatch(GamePlayDirector.EGameState.Failure);
+        }
+
+        /// <summary>
+        /// ゲーム成功時の処理
+        /// </summary>
+        protected override void OnSucceed()
+        {
+            base.OnSucceed();
+            EndProcess();
+        }
+
+        /// <summary>
+        /// ゲーム失敗時の処理
+        /// </summary>
+        protected override void OnFail()
+        {
+            base.OnFail();
+            EndProcess();
+        }
+
+        /// <summary>
+        /// ゲーム終了時の共通処理
+        /// </summary>
+        private void EndProcess()
+        {
+            // 自身が破壊されてない場合には，全ての自身のアニメーションを停止
+            if (!_dead) {
+                _anim.Stop();
+            }
         }
     }
 }


### PR DESCRIPTION
## 対象イシュー
Close #185

## 概要
ゲーム終了時に，失敗に関与したパネルのアニメーションが存在するのは問題ではないが（deadAnimation みたいなやつ），失敗に関与していないパネルのアニメーションが動き続けているため（現状はライフナンバーパネルがライフのこり1になった時に，攻撃を受けた時にアニメーションを繰り返すというもののみ），それを止めるようにした．

## 技術的な内容
Dynamic Panel にある OnSucceed と OnFail が成功時，失敗時に呼び出されるので，これをオーバーライドした．現状はナンバーパネルには失敗に関したパネルしかアニメーションを起こさないので必要ないが，一応ナンバーパネルにこの記述をおいた．