### PR TITLE
TurnCartridgeControllerのバグを直す

### DIFF
--- a/Assets/Project/Resources/GameDatas/Stages/2_4.asset
+++ b/Assets/Project/Resources/GameDatas/Stages/2_4.asset
@@ -1,0 +1,73 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a54e76f6c0ff74f77be74b799ca8ccc8, type: 3}
+  m_Name: 2_4
+  m_EditorClassIdentifier: 
+  id: 1004
+  bulletGroups:
+  - appearTime: 1
+    interval: 5
+    loop: 1
+    bullets:
+    - type: 1
+      ratio: 100
+      line: 1
+      direction: 1
+      turnDirections: 04000000010000000300000001000000
+      turnLines: 03000000020000000100000001000000
+      randomCartridgeDirection: 
+      randomRow: 
+      randomColumn: 
+      randomTurnDirection: 
+      randomTurnRow: 
+      randomTurnColumn: 
+  panels:
+  - type: 2
+    initPos: 7
+    number: 1
+    targetPos: 4
+    life: 0
+  - type: 2
+    initPos: 8
+    number: 2
+    targetPos: 5
+    life: 0
+  - type: 2
+    initPos: 9
+    number: 3
+    targetPos: 6
+    life: 0
+  - type: 2
+    initPos: 10
+    number: 4
+    targetPos: 7
+    life: 0
+  - type: 2
+    initPos: 11
+    number: 5
+    targetPos: 8
+    life: 0
+  - type: 2
+    initPos: 12
+    number: 6
+    targetPos: 9
+    life: 0
+  - type: 2
+    initPos: 13
+    number: 7
+    targetPos: 10
+    life: 0
+  - type: 2
+    initPos: 14
+    number: 8
+    targetPos: 11
+    life: 0

--- a/Assets/Project/Resources/GameDatas/Stages/2_4.asset.meta
+++ b/Assets/Project/Resources/GameDatas/Stages/2_4.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 80f965afa4a944ee99d79343061962bc
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/BulletGenerator.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/BulletGenerator.cs
@@ -12,7 +12,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
         // Generatorの出現する確率
         [NonSerialized] public int ratio = BulletGeneratorParameter.INITIAL_RATIO;
 
-        protected void Awake()
+        protected virtual void Awake()
         {
             gamePlayDirector = FindObjectOfType<GamePlayDirector>();
         }

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/TurnCartridgeController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/TurnCartridgeController.cs
@@ -66,6 +66,16 @@ namespace Project.Scripts.GamePlayScene.Bullet
         private bool _rotating = false;
 
         /// <summary>
+        /// 銃弾が待機しているかどうかを表す状態
+        /// </summary>
+        private bool _waiting = true;
+
+        /// <summary>
+        /// 銃弾が動き始めるまでの残りのフレーム数
+        /// </summary>
+        private int _waitingTime = TurnCartridgeGenerator.TURN_CARTRIDGE_WAITING_FRAMES;
+
+        /// <summary>
         /// 警告を表示し、銃弾を回転させるcoroutineの配列
         /// </summary>
         private IEnumerator[] rotateCoroutines;
@@ -99,12 +109,19 @@ namespace Project.Scripts.GamePlayScene.Bullet
                         _warningIndex++;
                 }
 
-                if (_rotating) {
-                    // 回転中
-                    transform.Translate(motionVector * _rotatingSpeed, Space.World);
+                if(_waiting) {
+                    // 待機中
+                    _waitingTime--;
+                    if(_waitingTime == 0) 
+                    _waiting = false;
                 } else {
-                    // 直進中
-                    transform.Translate(motionVector * speed, Space.World);
+                    if (_rotating) {
+                        // 回転中
+                        transform.Translate(motionVector * _rotatingSpeed, Space.World);
+                    } else {
+                        // 直進中
+                        transform.Translate(motionVector * speed, Space.World);
+                    }
                 }
             }
         }
@@ -148,7 +165,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
             // 1つ目の警告を表示させるタイミングを求める
             // 警告座標に到達する時間(= 銃弾が進む距離 / 銃弾の速さ)のNフレーム前が表示タイミング
             _warningTiming = new int[turnDirection.Length];
-            _warningTiming[0] = (int)Math.Round((Vector2.Distance(transform.position, _turnPoint[0]) - (PanelSize.WIDTH - CartridgeSize.WIDTH) / 2f) / speed - BulletWarningParameter.WARNING_DISPLAYED_FRAMES - _RUNNING_FRAME, MidpointRounding.AwayFromZero);
+            _warningTiming[0] = TurnCartridgeGenerator.TURN_CARTRIDGE_WAITING_FRAMES + (int)Math.Round((Vector2.Distance(transform.position, _turnPoint[0]) - (PanelSize.WIDTH - CartridgeSize.WIDTH) / 2f) / speed - BulletWarningParameter.WARNING_DISPLAYED_FRAMES - _RUNNING_FRAMES, MidpointRounding.AwayFromZero);
             // 警告の表示および銃弾が回転する挙動を特定のタイミングで発火できるようにcoroutineにセットする
             rotateCoroutines = new IEnumerator[turnDirection.Length];
             rotateCoroutines[0] = DisplayTurnWarning(_turnPoint[0], _turnDirection[0], _turnAngle[0]);

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/TurnCartridgeController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/TurnCartridgeController.cs
@@ -52,7 +52,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
         /// <summary>
         /// 警告表示後から銃弾が警告座標に到達するフレーム数
         /// </summary>
-        private const int _RUNNING_FRAME = 30;
+        private const int _RUNNING_FRAMES = 30;
 
         /// <summary>
         /// 回転中の銃弾の速さ (円周(= 回転半径 * 2 * pi)の4分の1をフレーム数で割る)
@@ -222,7 +222,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
             for (var index = 0; index < BulletWarningParameter.WARNING_DISPLAYED_FRAMES; index++) yield return new WaitForFixedUpdate();
             // 警告を削除する
             Destroy(_warning);
-            for (var index = 0; index < _RUNNING_FRAME; index++) yield return new WaitForFixedUpdate();
+            for (var index = 0; index < _RUNNING_FRAMES; index++) yield return new WaitForFixedUpdate();
             // 銃弾を回転させる
             StartCoroutine(RotateCartridge(turnAngle));
             yield break;

--- a/Assets/Project/Scripts/GamePlayScene/StageGenerator.cs
+++ b/Assets/Project/Scripts/GamePlayScene/StageGenerator.cs
@@ -311,36 +311,6 @@ namespace Project.Scripts.GamePlayScene
                     panelGenerator.CreateDynamicDummyPanel(initialTileNum: 3);
                     panelGenerator.CreateStaticDummyPanel(initialTileNum: 15);
                     break;
-                case 1004:
-                // 銃弾実体生成
-                    // TurnCartridgeを生成する
-                    coroutines.Add(bulletGroupGenerator.CreateBulletGroup(
-                            appearanceTime: 1.0f,
-                            interval: 5.0f,
-                            loop: true,
-                    bulletGenerators: new List<GameObject>() {
-                        bulletGroupGenerator.CreateTurnCartridgeGenerator(ratio: 100,
-                            cartridgeDirection: ECartridgeDirection.ToLeft, row: ERow.First,
-                            turnDirection: new int[] {(int) ECartridgeDirection.ToBottom, (int) ECartridgeDirection.ToLeft, (int) ECartridgeDirection.ToUp, (int) ECartridgeDirection.ToLeft},
-                            turnLine: new int[] {(int) EColumn.Right, (int) ERow.Second, (int) EColumn.Left, (int) ERow.First})
-                    }));
-                    /* 特殊タイル -> 数字パネル -> 特殊パネル */
-                    // 特殊タイル作成
-                    tileGenerator.CreateWarpTiles(firstTileNum: 2, secondTileNum: 14);
-                    // 数字パネル作成
-                    panelGenerator.PrepareTilesAndCreateNumberPanels(
-                    new List<Dictionary<string, int>>() {
-                        PanelGenerator.ComvartToDictionary(panelNum: 1, initialTileNum: 7, finalTileNum: 4),
-                                                           PanelGenerator.ComvartToDictionary(panelNum: 2, initialTileNum: 8, finalTileNum: 5),
-                                                           PanelGenerator.ComvartToDictionary(panelNum: 3, initialTileNum: 9, finalTileNum: 6),
-                                                           PanelGenerator.ComvartToDictionary(panelNum: 4, initialTileNum: 10, finalTileNum: 7),
-                                                           PanelGenerator.ComvartToDictionary(panelNum: 5, initialTileNum: 11, finalTileNum: 8),
-                                                           PanelGenerator.ComvartToDictionary(panelNum: 6, initialTileNum: 12, finalTileNum: 9),
-                                                           PanelGenerator.ComvartToDictionary(panelNum: 7, initialTileNum: 13, finalTileNum: 10),
-                                                           PanelGenerator.ComvartToDictionary(panelNum: 8, initialTileNum: 14, finalTileNum: 11)
-                    }
-                    );
-                    break;
                 default:
                     throw new NotImplementedException();
             }

--- a/Assets/Project/Scripts/GamePlayScene/StageGenerator.cs
+++ b/Assets/Project/Scripts/GamePlayScene/StageGenerator.cs
@@ -311,6 +311,36 @@ namespace Project.Scripts.GamePlayScene
                     panelGenerator.CreateDynamicDummyPanel(initialTileNum: 3);
                     panelGenerator.CreateStaticDummyPanel(initialTileNum: 15);
                     break;
+                case 1004:
+                // 銃弾実体生成
+                    // TurnCartridgeを生成する
+                    coroutines.Add(bulletGroupGenerator.CreateBulletGroup(
+                            appearanceTime: 1.0f,
+                            interval: 5.0f,
+                            loop: true,
+                    bulletGenerators: new List<GameObject>() {
+                        bulletGroupGenerator.CreateTurnCartridgeGenerator(ratio: 100,
+                            cartridgeDirection: ECartridgeDirection.ToLeft, row: ERow.First,
+                            turnDirection: new int[] {(int) ECartridgeDirection.ToBottom, (int) ECartridgeDirection.ToLeft, (int) ECartridgeDirection.ToUp, (int) ECartridgeDirection.ToLeft},
+                            turnLine: new int[] {(int) EColumn.Right, (int) ERow.Second, (int) EColumn.Left, (int) ERow.First})
+                    }));
+                    /* 特殊タイル -> 数字パネル -> 特殊パネル */
+                    // 特殊タイル作成
+                    tileGenerator.CreateWarpTiles(firstTileNum: 2, secondTileNum: 14);
+                    // 数字パネル作成
+                    panelGenerator.PrepareTilesAndCreateNumberPanels(
+                    new List<Dictionary<string, int>>() {
+                        PanelGenerator.ComvartToDictionary(panelNum: 1, initialTileNum: 7, finalTileNum: 4),
+                                                           PanelGenerator.ComvartToDictionary(panelNum: 2, initialTileNum: 8, finalTileNum: 5),
+                                                           PanelGenerator.ComvartToDictionary(panelNum: 3, initialTileNum: 9, finalTileNum: 6),
+                                                           PanelGenerator.ComvartToDictionary(panelNum: 4, initialTileNum: 10, finalTileNum: 7),
+                                                           PanelGenerator.ComvartToDictionary(panelNum: 5, initialTileNum: 11, finalTileNum: 8),
+                                                           PanelGenerator.ComvartToDictionary(panelNum: 6, initialTileNum: 12, finalTileNum: 9),
+                                                           PanelGenerator.ComvartToDictionary(panelNum: 7, initialTileNum: 13, finalTileNum: 10),
+                                                           PanelGenerator.ComvartToDictionary(panelNum: 8, initialTileNum: 14, finalTileNum: 11)
+                    }
+                    );
+                    break;
                 default:
                     throw new NotImplementedException();
             }


### PR DESCRIPTION
## 対象イシュー
Close #188

## バグの概要
- `TurnCartridge`が１つ目の角を曲がる時、曲がらずに直進していた。
- 銃弾生成時に、f = (A - (B + C))を計算している。
A : 銃弾が曲がる場所までの移動にかかるフレーム数
B : 曲がる場所の警告の表示フレーム数
C : 曲がる場所の警告を表示し終えてから銃弾が曲がるまでの余白フレーム数
１つ目の角の時は(f < 0)になっていて曲がらなかった。

## 改善の概要
- 銃弾生成の警告を表示し終えてから`TurnCartridge`を生成すると、１つ目の角で曲がる際の、曲がる場所の警告の表示時間を確保できないので、銃弾生成のタイミングを早めた。
- 銃弾生成のタイミングを早めたが、銃弾が移動するまでの待機時間を設けて、意図した時間に銃弾が画面内に出現するようにした。
- 簡単にいうと、銃弾が画面内に出現していないけど、１つ目の角に警告が表示されるようになったということです、

## 技術的な内容
`TurnCartridgeGenerator.cs`の`TURN_CARTRIDGE_WAITING_FRAMES`は`Time.fixedDeltaTime`を参照するので、コンストラクタで値を代入せずに`Awake()`や`Start()`で代入しないといけない。

## キャプチャ
![description](https://user-images.githubusercontent.com/26213141/69005133-b5cf6600-0960-11ea-9b4d-7905dfb1c27c.jpg)

