### PR TITLE
ゲームクリア時の戻るボタンの処理を消してしまっていたのを戻す

### DIFF
--- a/Assets/Project/Scripts/GamePlayScene/GamePlayDirector.cs
+++ b/Assets/Project/Scripts/GamePlayScene/GamePlayDirector.cs
@@ -342,6 +342,15 @@ namespace Project.Scripts.GamePlayScene
         }
 
         /// <summary>
+        /// 戻るボタン押下時の処理
+        /// </summary>
+        public void BackButtonDown()
+        {
+            // StageSelectSceneに戻る
+            SceneManager.LoadScene(SceneName.MENU_SELECT_SCENE);
+        }
+
+        /// <summary>
         /// 投稿ボタン押下時の処理
         /// </summary>
         public void ShareButtonDown()


### PR DESCRIPTION
## 対象イシュー
なし

## 概要
- ゲームクリア時に表示される戻るボタンの処理を #195 で誤って消してしまったので元に戻す

## 技術的な内容
なし

## キャプチャ

