### PR TITLE
StageDataにてrandom系のパラメータに配列の大きさの制約をかける

### DIFF
--- a/Assets/Project/Scripts/Editor/EditorExtension.cs
+++ b/Assets/Project/Scripts/Editor/EditorExtension.cs
@@ -1,0 +1,54 @@
+﻿using UnityEngine;
+using UnityEditor;
+using System;
+
+public static class EditorExtension
+{
+    /// <summary>
+    /// List、Arrayなどの配列型のPropertyを描画するメソッド
+    /// </summary>
+    /// <param name="property">描画する対象、配列である必要がある</param>
+    /// <param name="action">配列に格納する要素に対する描画処理、nullの場合はEditorGUI.PropertyFieldを使う</param>
+    public static void DrawArrayProperty(this Editor editor, SerializedProperty property, Action<SerializedProperty, int> action = null)
+    {
+        if (!property.isArray)
+            return;
+
+        property.isExpanded = EditorGUILayout.Foldout(property.isExpanded, property.displayName);
+        EditorGUILayout.PropertyField(property.FindPropertyRelative("Array.size"));
+        DrawArrayPropoeryImpl(property, action);
+    }
+
+    /// <summary>
+    /// 配列の大きさを制限した配列を描画する
+    /// <see cref="StageDataEditor.DrawArrayProperty(SerializedProperty, Action{SerializedProperty, int})"/>
+    /// </summary>
+    /// <param name="property"></param>
+    /// <param name="size"></param>
+    /// <param name="action"></param>
+    public static void DrawFixedSizeArrayProperty(this Editor editor, SerializedProperty property, int size, Action<SerializedProperty, int> action = null)
+    {
+        if (!property.isArray)
+            return;
+
+        property.arraySize = size;
+        property.isExpanded = EditorGUILayout.Foldout(property.isExpanded, property.displayName);
+        GUI.enabled = false;
+        EditorGUILayout.PropertyField(property.FindPropertyRelative("Array.size"));
+        GUI.enabled = true;
+        DrawArrayPropoeryImpl(property, action);
+    }
+
+    private static void DrawArrayPropoeryImpl(SerializedProperty property, Action<SerializedProperty, int> action = null) {
+        if (property.isExpanded) {
+            for (int i = 0 ; i < property.arraySize ; ++i) {
+                var arrayElementProperty = property.GetArrayElementAtIndex(i);
+                if (action != null) {
+                    action.Invoke(arrayElementProperty, i);
+                } else {
+                    EditorGUILayout.PropertyField(arrayElementProperty, new GUIContent(arrayElementProperty.displayName));
+                }
+            }
+        }
+    }
+}

--- a/Assets/Project/Scripts/Editor/EditorExtension.cs
+++ b/Assets/Project/Scripts/Editor/EditorExtension.cs
@@ -39,7 +39,8 @@ public static class EditorExtension
         DrawArrayPropoeryImpl(property, action);
     }
 
-    private static void DrawArrayPropoeryImpl(SerializedProperty property, Action<SerializedProperty, int> action = null) {
+    private static void DrawArrayPropoeryImpl(SerializedProperty property, Action<SerializedProperty, int> action = null)
+    {
         if (property.isExpanded) {
             for (int i = 0 ; i < property.arraySize ; ++i) {
                 var arrayElementProperty = property.GetArrayElementAtIndex(i);

--- a/Assets/Project/Scripts/Editor/EditorExtension.cs.meta
+++ b/Assets/Project/Scripts/Editor/EditorExtension.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6f703c56182b444fc96737cb2545a469
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/Scripts/Editor/StageDataEditor.cs
+++ b/Assets/Project/Scripts/Editor/StageDataEditor.cs
@@ -77,7 +77,7 @@ public class StageDataEditor : Editor
             }
         }
     }
-    
+
     private void DrawBulletGroupList()
     {
         this.DrawArrayProperty(_bulletGroupDatasProp, (bulletGroupDataProp, index) => {

--- a/Assets/Project/Scripts/Editor/StageDataEditor.cs
+++ b/Assets/Project/Scripts/Editor/StageDataEditor.cs
@@ -132,9 +132,9 @@ public class StageDataEditor : Editor
                                             checkEnabled: (eType) => (ECartridgeDirection)eType == ECartridgeDirection.Random,
                                             includeObsolete: false
                                         );
-                                    DrawArrayProperty(bulletDataProp.FindPropertyRelative("randomCartridgeDirection"));
-                                    DrawArrayProperty(bulletDataProp.FindPropertyRelative("randomRow"));
-                                    DrawArrayProperty(bulletDataProp.FindPropertyRelative("randomColumn"));
+                                    DrawFixedSizeArrayProperty(bulletDataProp.FindPropertyRelative("randomCartridgeDirection"), Enum.GetValues(typeof(ECartridgeDirection)).Length - 1);
+                                    DrawFixedSizeArrayProperty(bulletDataProp.FindPropertyRelative("randomRow"), Enum.GetValues(typeof(ERow)).Length - 1);
+                                    DrawFixedSizeArrayProperty(bulletDataProp.FindPropertyRelative("randomColumn"), Enum.GetValues(typeof(EColumn)).Length - 1);
                                     break;
                                 }
                             case EBulletType.TurnCartridge: {
@@ -172,15 +172,14 @@ public class StageDataEditor : Editor
                                             checkEnabled: (eType) => (ECartridgeDirection)eType == ECartridgeDirection.Random,
                                             includeObsolete: false
                                         );
-                                    DrawArrayProperty(bulletDataProp.FindPropertyRelative("randomCartridgeDirection"));
-                                    DrawArrayProperty(bulletDataProp.FindPropertyRelative("randomRow"));
-                                    DrawArrayProperty(bulletDataProp.FindPropertyRelative("randomColumn"));
-                                    DrawArrayProperty(bulletDataProp.FindPropertyRelative("randomTurnDirection"));
-                                    DrawArrayProperty(bulletDataProp.FindPropertyRelative("randomTurnRow"));
-                                    DrawArrayProperty(bulletDataProp.FindPropertyRelative("randomTurnColumn"));
+                                    DrawFixedSizeArrayProperty(bulletDataProp.FindPropertyRelative("randomCartridgeDirection"), Enum.GetValues(typeof(ECartridgeDirection)).Length - 1);
+                                    DrawFixedSizeArrayProperty(bulletDataProp.FindPropertyRelative("randomRow"), Enum.GetValues(typeof(ERow)).Length - 1);
+                                    DrawFixedSizeArrayProperty(bulletDataProp.FindPropertyRelative("randomColumn"), Enum.GetValues(typeof(EColumn)).Length - 1);
+                                    DrawFixedSizeArrayProperty(bulletDataProp.FindPropertyRelative("randomTurnDirection"), Enum.GetValues(typeof(ECartridgeDirection)).Length - 1);
+                                    DrawFixedSizeArrayProperty(bulletDataProp.FindPropertyRelative("randomTurnRow"), Enum.GetValues(typeof(ERow)).Length - 1);
+                                    DrawFixedSizeArrayProperty(bulletDataProp.FindPropertyRelative("randomTurnColumn"), Enum.GetValues(typeof(EColumn)).Length - 1);
                                     break;
                                 }
-
                         }
                     }
                 });
@@ -201,6 +200,36 @@ public class StageDataEditor : Editor
 
         property.isExpanded = EditorGUILayout.Foldout(property.isExpanded, property.displayName);
         EditorGUILayout.PropertyField(property.FindPropertyRelative("Array.size"));
+        if (property.isExpanded) {
+            for (int i = 0 ; i < property.arraySize ; ++i) {
+                var arrayElementProperty = property.GetArrayElementAtIndex(i);
+                if (action != null) {
+                    action.Invoke(arrayElementProperty, i);
+                } else {
+                    EditorGUILayout.PropertyField(arrayElementProperty, new GUIContent(arrayElementProperty.displayName));
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// 配列の大きさを制限した配列を描画する
+    /// <see cref="StageDataEditor.DrawArrayProperty(SerializedProperty, Action{SerializedProperty, int})"/>
+    /// </summary>
+    /// <param name="property"></param>
+    /// <param name="size"></param>
+    /// <param name="action"></param>
+    private static void DrawFixedSizeArrayProperty(SerializedProperty property, int size, Action<SerializedProperty, int> action = null)
+    {
+        if (!property.isArray)
+            return;
+
+        property.arraySize = size;
+        property.isExpanded = EditorGUILayout.Foldout(property.isExpanded, property.displayName);
+        GUI.enabled = false;
+        EditorGUILayout.PropertyField(property.FindPropertyRelative("Array.size"));
+        GUI.enabled = true;
+
         if (property.isExpanded) {
             for (int i = 0 ; i < property.arraySize ; ++i) {
                 var arrayElementProperty = property.GetArrayElementAtIndex(i);

--- a/Assets/Project/Scripts/Editor/StageDataEditor.cs
+++ b/Assets/Project/Scripts/Editor/StageDataEditor.cs
@@ -77,9 +77,10 @@ public class StageDataEditor : Editor
             }
         }
     }
+    
     private void DrawBulletGroupList()
     {
-        DrawArrayProperty(_bulletGroupDatasProp, (bulletGroupDataProp, index) => {
+        this.DrawArrayProperty(_bulletGroupDatasProp, (bulletGroupDataProp, index) => {
             bulletGroupDataProp.isExpanded = EditorGUILayout.Foldout(bulletGroupDataProp.isExpanded, $"Bullet Group {index + 1}");
             if (bulletGroupDataProp.isExpanded) {
                 EditorGUI.indentLevel++;
@@ -89,7 +90,7 @@ public class StageDataEditor : Editor
                 EditorGUILayout.PropertyField(bulletGroupDataProp.FindPropertyRelative("loop"));
 
                 SerializedProperty bulletListProp = bulletGroupDataProp.FindPropertyRelative("bullets");
-                DrawArrayProperty(bulletListProp, (bulletDataProp, index2) => {
+                this.DrawArrayProperty(bulletListProp, (bulletDataProp, index2) => {
                     bulletDataProp.isExpanded = EditorGUILayout.Foldout(bulletDataProp.isExpanded, $"Bullet {index2 + 1}");
                     if (bulletDataProp.isExpanded) {
                         SerializedProperty bulletTypeProp = bulletDataProp.FindPropertyRelative("type");
@@ -132,9 +133,9 @@ public class StageDataEditor : Editor
                                             checkEnabled: (eType) => (ECartridgeDirection)eType == ECartridgeDirection.Random,
                                             includeObsolete: false
                                         );
-                                    DrawFixedSizeArrayProperty(bulletDataProp.FindPropertyRelative("randomCartridgeDirection"), Enum.GetValues(typeof(ECartridgeDirection)).Length - 1);
-                                    DrawFixedSizeArrayProperty(bulletDataProp.FindPropertyRelative("randomRow"), Enum.GetValues(typeof(ERow)).Length - 1);
-                                    DrawFixedSizeArrayProperty(bulletDataProp.FindPropertyRelative("randomColumn"), Enum.GetValues(typeof(EColumn)).Length - 1);
+                                    this.DrawFixedSizeArrayProperty(bulletDataProp.FindPropertyRelative("randomCartridgeDirection"), Enum.GetValues(typeof(ECartridgeDirection)).Length - 1);
+                                    this.DrawFixedSizeArrayProperty(bulletDataProp.FindPropertyRelative("randomRow"), Enum.GetValues(typeof(ERow)).Length - 1);
+                                    this.DrawFixedSizeArrayProperty(bulletDataProp.FindPropertyRelative("randomColumn"), Enum.GetValues(typeof(EColumn)).Length - 1);
                                     break;
                                 }
                             case EBulletType.TurnCartridge: {
@@ -160,8 +161,8 @@ public class StageDataEditor : Editor
                                     }
 
                                     // TODO pair constraint of turnDirections/tunrLines
-                                    DrawArrayProperty(bulletDataProp.FindPropertyRelative("turnDirections"));
-                                    DrawArrayProperty(bulletDataProp.FindPropertyRelative("turnLines"));
+                                    this.DrawArrayProperty(bulletDataProp.FindPropertyRelative("turnDirections"));
+                                    this.DrawArrayProperty(bulletDataProp.FindPropertyRelative("turnLines"));
                                     break;
                                 }
                             case EBulletType.RandomTurnCartridge: {
@@ -172,12 +173,12 @@ public class StageDataEditor : Editor
                                             checkEnabled: (eType) => (ECartridgeDirection)eType == ECartridgeDirection.Random,
                                             includeObsolete: false
                                         );
-                                    DrawFixedSizeArrayProperty(bulletDataProp.FindPropertyRelative("randomCartridgeDirection"), Enum.GetValues(typeof(ECartridgeDirection)).Length - 1);
-                                    DrawFixedSizeArrayProperty(bulletDataProp.FindPropertyRelative("randomRow"), Enum.GetValues(typeof(ERow)).Length - 1);
-                                    DrawFixedSizeArrayProperty(bulletDataProp.FindPropertyRelative("randomColumn"), Enum.GetValues(typeof(EColumn)).Length - 1);
-                                    DrawFixedSizeArrayProperty(bulletDataProp.FindPropertyRelative("randomTurnDirection"), Enum.GetValues(typeof(ECartridgeDirection)).Length - 1);
-                                    DrawFixedSizeArrayProperty(bulletDataProp.FindPropertyRelative("randomTurnRow"), Enum.GetValues(typeof(ERow)).Length - 1);
-                                    DrawFixedSizeArrayProperty(bulletDataProp.FindPropertyRelative("randomTurnColumn"), Enum.GetValues(typeof(EColumn)).Length - 1);
+                                    this.DrawFixedSizeArrayProperty(bulletDataProp.FindPropertyRelative("randomCartridgeDirection"), Enum.GetValues(typeof(ECartridgeDirection)).Length - 1);
+                                    this.DrawFixedSizeArrayProperty(bulletDataProp.FindPropertyRelative("randomRow"), Enum.GetValues(typeof(ERow)).Length - 1);
+                                    this.DrawFixedSizeArrayProperty(bulletDataProp.FindPropertyRelative("randomColumn"), Enum.GetValues(typeof(EColumn)).Length - 1);
+                                    this.DrawFixedSizeArrayProperty(bulletDataProp.FindPropertyRelative("randomTurnDirection"), Enum.GetValues(typeof(ECartridgeDirection)).Length - 1);
+                                    this.DrawFixedSizeArrayProperty(bulletDataProp.FindPropertyRelative("randomTurnRow"), Enum.GetValues(typeof(ERow)).Length - 1);
+                                    this.DrawFixedSizeArrayProperty(bulletDataProp.FindPropertyRelative("randomTurnColumn"), Enum.GetValues(typeof(EColumn)).Length - 1);
                                     break;
                                 }
                         }
@@ -186,59 +187,5 @@ public class StageDataEditor : Editor
                 EditorGUI.indentLevel--;
             }
         });
-    }
-
-    /// <summary>
-    /// List、Arrayなどの配列型のPropertyを描画するメソッド
-    /// </summary>
-    /// <param name="property">描画する対象、配列である必要がある</param>
-    /// <param name="action">配列に格納する要素に対する描画処理、nullの場合はEditorGUI.PropertyFieldを使う</param>
-    private static void DrawArrayProperty(SerializedProperty property, Action<SerializedProperty, int> action = null)
-    {
-        if (!property.isArray)
-            return;
-
-        property.isExpanded = EditorGUILayout.Foldout(property.isExpanded, property.displayName);
-        EditorGUILayout.PropertyField(property.FindPropertyRelative("Array.size"));
-        if (property.isExpanded) {
-            for (int i = 0 ; i < property.arraySize ; ++i) {
-                var arrayElementProperty = property.GetArrayElementAtIndex(i);
-                if (action != null) {
-                    action.Invoke(arrayElementProperty, i);
-                } else {
-                    EditorGUILayout.PropertyField(arrayElementProperty, new GUIContent(arrayElementProperty.displayName));
-                }
-            }
-        }
-    }
-
-    /// <summary>
-    /// 配列の大きさを制限した配列を描画する
-    /// <see cref="StageDataEditor.DrawArrayProperty(SerializedProperty, Action{SerializedProperty, int})"/>
-    /// </summary>
-    /// <param name="property"></param>
-    /// <param name="size"></param>
-    /// <param name="action"></param>
-    private static void DrawFixedSizeArrayProperty(SerializedProperty property, int size, Action<SerializedProperty, int> action = null)
-    {
-        if (!property.isArray)
-            return;
-
-        property.arraySize = size;
-        property.isExpanded = EditorGUILayout.Foldout(property.isExpanded, property.displayName);
-        GUI.enabled = false;
-        EditorGUILayout.PropertyField(property.FindPropertyRelative("Array.size"));
-        GUI.enabled = true;
-
-        if (property.isExpanded) {
-            for (int i = 0 ; i < property.arraySize ; ++i) {
-                var arrayElementProperty = property.GetArrayElementAtIndex(i);
-                if (action != null) {
-                    action.Invoke(arrayElementProperty, i);
-                } else {
-                    EditorGUILayout.PropertyField(arrayElementProperty, new GUIContent(arrayElementProperty.displayName));
-                }
-            }
-        }
     }
 }


### PR DESCRIPTION
## 対象イシュー

close #215 

## 概要
int[4] randomCartridgeDirection;
int[5] randomRow;
int[3] randomColumn;
int[4] randomTurnDirection;
int[5] randomTurnRow;
int[3] randomTurnColumn;
上記パラメータの大きさの制限を加えた。

(int[the number of NumberPanels in the stage] randomNumberPanel; // AimingHoleのパラメータ)
に関して、 @takasusuke の実装を待つか、このコミットを取り入れてもらって @takasusuke にやってもらうかのどちらかと思います。

## 技術的な内容

`DrawArrayProperty` の代わりに、 `DrawFixedSizeArrayProperty` を使って配列の大きさを与え、エディターでの配列の大きさの操作を拒否する。

## キャプチャ
![image](https://user-images.githubusercontent.com/17778395/69490293-cafc4580-0ec8-11ea-80fe-08c2f17deff7.png)


## その他
1. `DrawArrayProperty` , `DrawFixedSizeArrayProperty ` 等のメソッドは `StageDataEditor` のメンバメソッドっていうのはなんか気持ち悪いから、後ほど別タスクで `UnityEditor.Editor` の拡張メソッドにしたいと思う。
2. 画像でごらんの通り、Element0とか訳わからないから、なんかEnumの文字列入れた方が良いと思うけど、どうかな。
