### PR TITLE
タイルの作成後にパネルを作成するようにする (GUI 非対応)

### DIFF
--- a/Assets/Project/Scripts/GamePlayScene/Panel/NumberPanelController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Panel/NumberPanelController.cs
@@ -14,7 +14,7 @@ namespace Project.Scripts.GamePlayScene.Panel
         /// <summary>
         /// パネルのゴールとなるタイル
         /// </summary>
-        private GameObject _finalTile;
+        public GameObject finalTile;
 
         /// <summary>
         /// パネルの番号
@@ -60,7 +60,7 @@ namespace Project.Scripts.GamePlayScene.Panel
         {
             base.Start();
             // 初期状態で最終タイルにいるかどうかの状態を変える
-            Adapted = transform.parent.gameObject == _finalTile;
+            Adapted = transform.parent.gameObject == finalTile;
             // 最終タイルにいるかどうかで，光らせるかを決める
             GetComponent<SpriteGlowEffect>().enabled = Adapted;
         }
@@ -75,7 +75,7 @@ namespace Project.Scripts.GamePlayScene.Panel
         {
             Initialize(initialTileNum);
             name = PanelName.NUMBER_PANEL + panelNum;
-            _finalTile = TileLibrary.GetTile(finalTileNum);
+            finalTile = TileLibrary.GetTile(finalTileNum);
             this._panelNum = panelNum;
         }
 
@@ -98,7 +98,7 @@ namespace Project.Scripts.GamePlayScene.Panel
             base.UpdateTile(targetTile);
 
             // 最終タイルにいるかどうかで状態を変える
-            Adapted = transform.parent.gameObject == _finalTile;
+            Adapted = transform.parent.gameObject == finalTile;
             // 最終タイルにいるかどうかで，光らせるかを決める
             GetComponent<SpriteGlowEffect>().enabled = Adapted;
             // adapted が true になっていれば (必要条件) 成功判定をする

--- a/Assets/Project/Scripts/GamePlayScene/Panel/PanelGenerator.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Panel/PanelGenerator.cs
@@ -113,7 +113,7 @@ namespace Project.Scripts.GamePlayScene.Panel
                 var panel = Instantiate(_lifeNumberPanelPrefab);
                 var sprite = Resources.Load<Sprite>("Textures/Panel/lifeNumberPanel" + panelNum);
                 if (sprite != null) panel.GetComponent<SpriteRenderer>().sprite = sprite;
-                panel.GetComponent<NumberPanelController>().Initialize(panelNum, initialTileNum, finalTileNum);
+                panel.GetComponent<LifeNumberPanelController>().Initialize(panelNum, initialTileNum, finalTileNum);
             }
         }
 

--- a/Assets/Project/Scripts/GamePlayScene/Panel/PanelGenerator.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Panel/PanelGenerator.cs
@@ -65,19 +65,8 @@ namespace Project.Scripts.GamePlayScene.Panel
         /// 必要なタイルを準備してから，数字パネルを作成する
         /// </summary>
         /// <param name="numberPanelParams"> ComvartToDictionary によって変換された辞書型リスト </param>
-        public void PrepareTilesAndCreateNumberPanels(List<Dictionary<string, int>> numberPanelParams)
+        public void CreateNumberPanels(List<Dictionary<string, int>> numberPanelParams)
         {
-            foreach (Dictionary<string, int> numberPanelParam in numberPanelParams) {
-                // パラメータの取得
-                var panelNum = numberPanelParam["panelNum"];
-                var finalTileNum = numberPanelParam["finalTileNum"];
-                // 数字タイルの作成
-                _tileGenerator.CreateNumberTile(panelNum, finalTileNum);
-            }
-
-            // ノーマルタイルの一括作成
-            _tileGenerator.CreateNormalTiles();
-
             foreach (Dictionary<string, int> numberPanelParam in numberPanelParams) {
                 // パラメータの取得
                 var panelNum = numberPanelParam["panelNum"];
@@ -88,22 +77,13 @@ namespace Project.Scripts.GamePlayScene.Panel
                 var sprite = Resources.Load<Sprite>("Textures/Panel/numberPanel" + panelNum);
                 if (sprite != null) panel.GetComponent<SpriteRenderer>().sprite = sprite;
                 panel.GetComponent<NumberPanelController>().Initialize(panelNum, initialTileNum, finalTileNum);
+                // 数字パネルのゴール番号に合わせて，タイルの画像を変更
+                panel.GetComponent<NumberPanelController>().finalTile.GetComponent<NormalTileController>().SetSprite(panelNum);
             }
         }
 
-        public void PrepareTilesAndCreateLifeNumberPanels(List<Dictionary<string, int>> numberPanelParams)
+        public void CreateLifeNumberPanels(List<Dictionary<string, int>> numberPanelParams)
         {
-            foreach (Dictionary<string, int> numberPanelParam in numberPanelParams) {
-                // パラメータの取得
-                var panelNum = numberPanelParam["panelNum"];
-                var finalTileNum = numberPanelParam["finalTileNum"];
-                // 数字タイルの作成
-                _tileGenerator.CreateNumberTile(panelNum, finalTileNum);
-            }
-
-            // ノーマルタイルの一括作成
-            _tileGenerator.CreateNormalTiles();
-
             foreach (Dictionary<string, int> numberPanelParam in numberPanelParams) {
                 // パラメータの取得
                 var panelNum = numberPanelParam["panelNum"];
@@ -114,6 +94,8 @@ namespace Project.Scripts.GamePlayScene.Panel
                 var sprite = Resources.Load<Sprite>("Textures/Panel/lifeNumberPanel" + panelNum);
                 if (sprite != null) panel.GetComponent<SpriteRenderer>().sprite = sprite;
                 panel.GetComponent<LifeNumberPanelController>().Initialize(panelNum, initialTileNum, finalTileNum);
+                // 数字パネルのゴール番号に合わせて，タイルの画像を変更
+                panel.GetComponent<LifeNumberPanelController>().finalTile.GetComponent<NormalTileController>().SetSprite(panelNum);
             }
         }
 

--- a/Assets/Project/Scripts/GamePlayScene/StageGenerator.cs
+++ b/Assets/Project/Scripts/GamePlayScene/StageGenerator.cs
@@ -63,8 +63,9 @@ namespace Project.Scripts.GamePlayScene
                             column: EColumn.Left)
                     }));
                     /* 特殊タイル -> 数字パネル -> 特殊パネル */
+                    tileGenerator.CreateNormalTiles();
                     // 数字パネル作成
-                    panelGenerator.PrepareTilesAndCreateNumberPanels(
+                    panelGenerator.CreateNumberPanels(
                     new List<Dictionary<string, int>>() {
                         PanelGenerator.ComvartToDictionary(panelNum: 1, initialTileNum: 4, finalTileNum: 4),
                                                            PanelGenerator.ComvartToDictionary(panelNum: 2, initialTileNum: 5, finalTileNum: 5),
@@ -91,8 +92,9 @@ namespace Project.Scripts.GamePlayScene
                         bulletGroupGenerator.CreateAimingHoleGenerator(ratio: 100, aimingPanel: new int[] {1})
                     }));
                     /* 特殊タイル -> 数字パネル -> 特殊パネル */
+                    tileGenerator.CreateNormalTiles();
                     // 数字パネル作成
-                    panelGenerator.PrepareTilesAndCreateNumberPanels(
+                    panelGenerator.CreateNumberPanels(
                     new List<Dictionary<string, int>>() {
                         PanelGenerator.ComvartToDictionary(panelNum: 1, initialTileNum: 4, finalTileNum: 4),
                                                            PanelGenerator.ComvartToDictionary(panelNum: 2, initialTileNum: 5, finalTileNum: 5),
@@ -120,8 +122,9 @@ namespace Project.Scripts.GamePlayScene
                                                     randomRow: new int[] {100, 5, 5, 5, 100}, randomColumn: new int[] {100, 10, 0}),
                     }));
                     /* 特殊タイル -> 数字パネル -> 特殊パネル */
+                    tileGenerator.CreateNormalTiles();
                     // 数字パネル作成
-                    panelGenerator.PrepareTilesAndCreateNumberPanels(
+                    panelGenerator.CreateNumberPanels(
                     new List<Dictionary<string, int>>() {
                         PanelGenerator.ComvartToDictionary(panelNum: 1, initialTileNum: 4, finalTileNum: 4),
                                                            PanelGenerator.ComvartToDictionary(panelNum: 2, initialTileNum: 5, finalTileNum: 5),
@@ -148,8 +151,9 @@ namespace Project.Scripts.GamePlayScene
                                         randomRow: new int[] {100, 20, 20, 20, 100}, randomColumn: new int[] {30, 100, 30})
                     }));
                     /* 特殊タイル -> 数字パネル -> 特殊パネル */
+                    tileGenerator.CreateNormalTiles();
                     // 数字パネル作成
-                    panelGenerator.PrepareTilesAndCreateNumberPanels(
+                    panelGenerator.CreateNumberPanels(
                     new List<Dictionary<string, int>>() {
                         PanelGenerator.ComvartToDictionary(panelNum: 1, initialTileNum: 4, finalTileNum: 4),
                                                            PanelGenerator.ComvartToDictionary(panelNum: 2, initialTileNum: 5, finalTileNum: 5),
@@ -175,8 +179,9 @@ namespace Project.Scripts.GamePlayScene
                                                                                randomNumberPanel: new int[] {10, 0, 10, 0, 10, 0, 10, 10})
                     }));
                     /* 特殊タイル -> 数字パネル -> 特殊パネル */
+                    tileGenerator.CreateNormalTiles();
                     // 数字パネル作成
-                    panelGenerator.PrepareTilesAndCreateNumberPanels(
+                    panelGenerator.CreateNumberPanels(
                     new List<Dictionary<string, int>>() {
                         PanelGenerator.ComvartToDictionary(panelNum: 1, initialTileNum: 4, finalTileNum: 4),
                                                            PanelGenerator.ComvartToDictionary(panelNum: 2, initialTileNum: 5, finalTileNum: 5),
@@ -211,8 +216,9 @@ namespace Project.Scripts.GamePlayScene
                                            randomNumberPanel: new int[] {10, 10, 10, 10, 10, 10, 10, 10})
                     }));
                     /* 特殊タイル -> 数字パネル -> 特殊パネル */
+                    tileGenerator.CreateNormalTiles();
                     // 数字パネル作成
-                    panelGenerator.PrepareTilesAndCreateNumberPanels(
+                    panelGenerator.CreateNumberPanels(
                     new List<Dictionary<string, int>>() {
                         PanelGenerator.ComvartToDictionary(panelNum: 1, initialTileNum: 4, finalTileNum: 4),
                                                            PanelGenerator.ComvartToDictionary(panelNum: 2, initialTileNum: 5, finalTileNum: 5),
@@ -232,8 +238,9 @@ namespace Project.Scripts.GamePlayScene
                     // 銃弾実体生成
                     // 銃弾を生成しない
                     /* 特殊タイル -> 数字パネル -> 特殊パネル */
+                    tileGenerator.CreateNormalTiles();
                     // 数字パネル作成
-                    panelGenerator.PrepareTilesAndCreateNumberPanels(
+                    panelGenerator.CreateNumberPanels(
                     new List<Dictionary<string, int>>() {
                         PanelGenerator.ComvartToDictionary(panelNum: 1, initialTileNum: 4, finalTileNum: 4),
                                                            PanelGenerator.ComvartToDictionary(panelNum: 2, initialTileNum: 5, finalTileNum: 5),
@@ -264,8 +271,9 @@ namespace Project.Scripts.GamePlayScene
                                                     cartridgeDirection: ECartridgeDirection.Random, row: ERow.Random)
                     }));
                     /* 特殊タイル -> 数字パネル -> 特殊パネル */
+                    tileGenerator.CreateNormalTiles();
                     // 数字パネル作成
-                    panelGenerator.PrepareTilesAndCreateLifeNumberPanels(
+                    panelGenerator.CreateLifeNumberPanels(
                     new List<Dictionary<string, int>>() {
                         PanelGenerator.ComvartToDictionary(panelNum: 1, initialTileNum: 4, finalTileNum: 4),
                                                            PanelGenerator.ComvartToDictionary(panelNum: 2, initialTileNum: 5, finalTileNum: 5),
@@ -294,8 +302,9 @@ namespace Project.Scripts.GamePlayScene
                                                                              bulletGroupGenerator.CreateRandomAimingHoleGenerator(10, new int[] {1, 1, 1, 1, 1, 1, 1, 1})
                     }));
                     /* 特殊タイル -> 数字パネル -> 特殊パネル */
+                    tileGenerator.CreateNormalTiles();
                     // 数字パネル作成
-                    panelGenerator.PrepareTilesAndCreateLifeNumberPanels(
+                    panelGenerator.CreateLifeNumberPanels(
                     new List<Dictionary<string, int>>() {
                         PanelGenerator.ComvartToDictionary(panelNum: 1, initialTileNum: 4, finalTileNum: 4),
                                                            PanelGenerator.ComvartToDictionary(panelNum: 2, initialTileNum: 5, finalTileNum: 5),

--- a/Assets/Project/Scripts/GamePlayScene/Tile/NormalTileController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Tile/NormalTileController.cs
@@ -98,5 +98,15 @@ namespace Project.Scripts.GamePlayScene.Tile
         {
             hasPanel = false;
         }
+
+        /// <summary>
+        /// 番号に合わせた画像に変更
+        /// </summary>
+        /// <param name="panelNum"> このタイルをゴールとするパネルの番号 </param>
+        public void SetSprite(int panelNum)
+        {
+            var sprite = Resources.Load<Sprite>("Textures/Tile/numberTile" + panelNum);
+            if (sprite != null) GetComponent<SpriteRenderer>().sprite = sprite;
+        }
     }
 }


### PR DESCRIPTION
## 対象イシュー
Close #213 

## 概要
- パネルを作成する際に，同時にタイル作成をしていた問題を修正
- @takesi0627 が作った GUI でのステージ作成機能には対応していない (タイルが実装されていないため) ので，レガシーコードはまだ残してある
- numberTile を削除し，normalTile が画像を差し替えるという機能を持つこととする．これは，現状 numberTile は一切の機能を持たず，normalTile の画像だけが異なるという点が不適だと考えてこうした．
- 流れとしては，タイル (normalTile or warpTile) を作成 -> パネルを作成 -> numberPanel of lifeNumberPanel の場合には，それらの Panel のゴールとなる normalTile に関しては，画像を差し替えるという処理で，問題を解決した