### PR TITLE
ワーニング修正

### DIFF
--- a/Assets/Project/Scripts/GamePlayScene/Bullet/NormalHoleController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/NormalHoleController.cs
@@ -115,7 +115,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
             // パネルより手前のレイヤー(BULLET)に描画する
             gameObject.GetComponent<Renderer>().sortingLayerName = SortingLayerName.BULLET;
             // holeを衝突したパネルに追従させる
-            gameObject.transform.parent = other.transform;
+            gameObject.transform.SetParent(other.transform);
         }
     }
 }

--- a/Assets/Project/Scripts/GamePlayScene/Panel/DynamicPanelController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Panel/DynamicPanelController.cs
@@ -19,7 +19,7 @@ namespace Project.Scripts.GamePlayScene.Panel
         /// ワープタイルでワープする時のアニメーション
         /// </summary>
         [SerializeField] protected AnimationClip warpAnimation;
-        
+
         /// <summary>
         /// ワープタイルでワープした後のアニメーション
         /// </summary>
@@ -108,7 +108,7 @@ namespace Project.Scripts.GamePlayScene.Panel
             if (targetScript.hasPanel) return;
             // 親タイルの更新
             transform.parent.GetComponent<NormalTileController>().LeavePanel(gameObject);
-            transform.parent = targetTile.transform;
+            transform.SetParent(targetTile.transform);
             // 親タイルへ移動
             transform.position = transform.parent.position;
             // 親タイルの副作用

--- a/Assets/Project/Scripts/GamePlayScene/Panel/PanelController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Panel/PanelController.cs
@@ -27,7 +27,7 @@ namespace Project.Scripts.GamePlayScene.Panel
             var initialTile = TileLibrary.GetTile(initialTileNum);
             var script = initialTile.GetComponent<NormalTileController>();
             script.hasPanel = true;
-            transform.parent = initialTile.transform;
+            transform.SetParent(initialTile.transform);
             transform.position = initialTile.transform.position;
         }
     }

--- a/Assets/Project/Scripts/GamePlayScene/Tile/WarpTileController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Tile/WarpTileController.cs
@@ -16,11 +16,12 @@ namespace Project.Scripts.GamePlayScene.Tile
         /// </summary>
         private GameObject warpTileEffect;
 
-        protected override void Awake() {
+        protected override void Awake()
+        {
             base.Awake();
             warpTileEffect = transform.Find("warpTileEffectPrefab").gameObject;
         }
-        
+
         /// <summary>
         /// 初期化
         /// </summary>
@@ -46,15 +47,18 @@ namespace Project.Scripts.GamePlayScene.Tile
             GamePlayDirector.OnFail -= OnFail;
         }
 
-        private void OnSucceed() {
+        private void OnSucceed()
+        {
             EndProcess();
         }
 
-        private void OnFail() {
+        private void OnFail()
+        {
             EndProcess();
         }
 
-        private void EndProcess() {
+        private void EndProcess()
+        {
             // 粒子アニメーションの生成を止める
             GetComponent<ParticleSystem>().Stop();
             // すでに生成された粒子を消す
@@ -87,7 +91,7 @@ namespace Project.Scripts.GamePlayScene.Tile
             while (anim.isPlaying) yield return new WaitForFixedUpdate();
             // panelの座標の更新
             LeavePanel(panel);
-            panel.transform.parent = _pairTile.transform;
+            panel.transform.SetParent(_pairTile.transform);
             _pairTile.GetComponent<NormalTileController>().hasPanel = true;
             panel.transform.position = _pairTile.transform.position;
             // panelがワープから戻るアニメーション


### PR DESCRIPTION
## 対象イシュー

close #228 

## 概要
`transform.parent` を直接値を設定すると #228 の図のようなwarningが出るので、そのような箇所を洗い出して `transform.SetParent` に変えました。

## 技術的な内容
VSCodeのfind all reference機能を使ってプロジェクトを検索した結果ThirdPartyのところも二カ所使ってるのでそちらも修正しました。

## キャプチャ

## その他
ステージに入ってパネルを動いたりクリアしたりして、Warningがでないことを確認してください。