### PR TITLE
Touch scriptのデバッグプリントを消す

### DIFF
--- a/Assets/Project/Scenes/GamePlayScene.unity
+++ b/Assets/Project/Scenes/GamePlayScene.unity
@@ -301,6 +301,7 @@ GameObject:
   - component: {fileID: 574476886}
   - component: {fileID: 574476885}
   - component: {fileID: 574476889}
+  - component: {fileID: 574476890}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -441,6 +442,30 @@ MonoBehaviour:
   m_BeforeTransparentBundles: []
   m_BeforeStackBundles: []
   m_AfterStackBundles: []
+--- !u!114 &574476890
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 574476884}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7e5768c36d1bb4acea50bd233372843a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Name: Main Camera
+  basicEditor: 1
+  advancedProps: 0
+  hitProps: 0
+  hit3DObjects: 1
+  hit2DObjects: 1
+  hitWorldSpaceUI: 1
+  hitScreenSpaceUI: 1
+  layerMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  useHitFilters: 0
 --- !u!1 &719677482
 GameObject:
   m_ObjectHideFlags: 0
@@ -484,8 +509,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 633aaf5d1ee7d4e199e9bb156394d2b4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _numberTilePrefab: {fileID: 1720766100627462, guid: 6e8ebbff6e8d3414faa3cfb592dc19e2,
-    type: 3}
   _normalTilePrefab: {fileID: 1202584627454472, guid: 10615e735d661461a88777d89755bf0e,
     type: 3}
   _warpTilePrefab: {fileID: 2281809373051226156, guid: 8bd35c0dfc09c48479577e2b43dcac03,
@@ -779,43 +802,27 @@ MonoBehaviour:
   OnFrameStart:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: TouchScript.TouchManager+FrameEvent, Assembly-CSharp, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   OnFrameFinish:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: TouchScript.TouchManager+FrameEvent, Assembly-CSharp, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   OnPointersAdd:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: TouchScript.TouchManager+PointerEvent, Assembly-CSharp, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   OnPointersUpdate:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: TouchScript.TouchManager+PointerEvent, Assembly-CSharp, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   OnPointersPress:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: TouchScript.TouchManager+PointerEvent, Assembly-CSharp, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   OnPointersRelease:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: TouchScript.TouchManager+PointerEvent, Assembly-CSharp, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   OnPointersRemove:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: TouchScript.TouchManager+PointerEvent, Assembly-CSharp, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   OnPointersCancel:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: TouchScript.TouchManager+PointerEvent, Assembly-CSharp, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   basicEditor: 1
   displayDevice: {fileID: 0}
   shouldCreateCameraLayer: 1

--- a/Assets/Project/Scenes/MenuSelectScene.unity
+++ b/Assets/Project/Scenes/MenuSelectScene.unity
@@ -253,43 +253,27 @@ MonoBehaviour:
   OnFrameStart:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: TouchScript.TouchManager+FrameEvent, Assembly-CSharp, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   OnFrameFinish:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: TouchScript.TouchManager+FrameEvent, Assembly-CSharp, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   OnPointersAdd:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: TouchScript.TouchManager+PointerEvent, Assembly-CSharp, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   OnPointersUpdate:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: TouchScript.TouchManager+PointerEvent, Assembly-CSharp, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   OnPointersPress:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: TouchScript.TouchManager+PointerEvent, Assembly-CSharp, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   OnPointersRelease:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: TouchScript.TouchManager+PointerEvent, Assembly-CSharp, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   OnPointersRemove:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: TouchScript.TouchManager+PointerEvent, Assembly-CSharp, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   OnPointersCancel:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: TouchScript.TouchManager+PointerEvent, Assembly-CSharp, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   basicEditor: 1
   displayDevice: {fileID: 0}
   shouldCreateCameraLayer: 1
@@ -708,6 +692,7 @@ GameObject:
   - component: {fileID: 645664157}
   - component: {fileID: 645664156}
   - component: {fileID: 645664155}
+  - component: {fileID: 645664154}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -715,6 +700,30 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
+--- !u!114 &645664154
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 645664153}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7e5768c36d1bb4acea50bd233372843a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Name: Main Camera
+  basicEditor: 1
+  advancedProps: 0
+  hitProps: 0
+  hit3DObjects: 1
+  hit2DObjects: 1
+  hitWorldSpaceUI: 1
+  hitScreenSpaceUI: 1
+  layerMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  useHitFilters: 0
 --- !u!124 &645664155
 Behaviour:
   m_ObjectHideFlags: 0

--- a/Assets/ThirdParties/TouchScript/Scripts/InputSources/StandardInput.cs
+++ b/Assets/ThirdParties/TouchScript/Scripts/InputSources/StandardInput.cs
@@ -467,7 +467,7 @@ namespace TouchScript.InputSources
             mouseHandler = new MouseHandler(addPointer, updatePointer, pressPointer, releasePointer, removePointer, cancelPointer);
             mouseHandler.EmulateSecondMousePointer = emulateSecondMousePointer;
             /*
-                copyright (c) 2019 Keisuke Yamakawa and other contributors.
+                Copyright (c) 2019 Keisuke Yamakawa and other contributors.
                 // Debug.Log("[TouchScript] Initialized Unity mouse input.");
             */
         }
@@ -484,7 +484,7 @@ namespace TouchScript.InputSources
         {
             touchHandler = new TouchHandler(addPointer, updatePointer, pressPointer, releasePointer, removePointer, cancelPointer);
             /*
-                copyright (c) 2019 Keisuke Yamakawa and other contributors.
+                Copyright (c) 2019 Keisuke Yamakawa and other contributors.
                 // Debug.Log("[TouchScript] Initialized Unity touch input.");
             */
         }

--- a/Assets/ThirdParties/TouchScript/Scripts/InputSources/StandardInput.cs
+++ b/Assets/ThirdParties/TouchScript/Scripts/InputSources/StandardInput.cs
@@ -466,7 +466,10 @@ namespace TouchScript.InputSources
         {
             mouseHandler = new MouseHandler(addPointer, updatePointer, pressPointer, releasePointer, removePointer, cancelPointer);
             mouseHandler.EmulateSecondMousePointer = emulateSecondMousePointer;
-            Debug.Log("[TouchScript] Initialized Unity mouse input.");
+            /*
+                copyright (c) 2019 Keisuke Yamakawa and other contributors.
+                // Debug.Log("[TouchScript] Initialized Unity mouse input.");
+            */
         }
 
         private void disableMouse()
@@ -480,7 +483,10 @@ namespace TouchScript.InputSources
         private void enableTouch()
         {
             touchHandler = new TouchHandler(addPointer, updatePointer, pressPointer, releasePointer, removePointer, cancelPointer);
-            Debug.Log("[TouchScript] Initialized Unity touch input.");
+            /*
+                copyright (c) 2019 Keisuke Yamakawa and other contributors.
+                // Debug.Log("[TouchScript] Initialized Unity touch input.");
+            */
         }
 
         private void disableTouch()

--- a/Assets/ThirdParties/TouchScript/license.txt
+++ b/Assets/ThirdParties/TouchScript/license.txt
@@ -1,5 +1,28 @@
 This software is distributed under The MIT License (MIT).
 
+Copyright (c) 2019 Keisuke Yamakawa and other contributors.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+The major design of this asset was from Valentin Simonov and other contributors, which is subject to the same license.
+Here is the original copyright notice:
+
 Copyright (c) 2015 Valentin Simonov and other contributors.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
## 対象イシュー
Close #231

## 概要
- `[TouchScript] No touch layers found, adding StandardLayer for main camera. (this message is harmless)`のデバッグプリントは、文言通り、カメラに`StanderdLayer.cs`がアタッチされていないことによるデバッグプリントなので、アタッチしました。
- `Initialized Unity touch(mouse) input`のデバッグプリントはEditorで動かしているなら必ず表示されます。`TouchScript`はMITライセンスなので、複製、改変、再頒布等自由であり、これを使ったコードの公開義務もありませんが、もし公開するなら、MITライセンスの条文表示と元の著作権表示を行うことが義務付けられています。
改変しても著作権表示を行えば、改変箇所および改変したことを明記する必要はなさそうです。しかし、改変記述を行うことが礼儀？慣習？であるようなので、参考URLを基に、改変したことを示すcopyrightを追加しました。

## 技術的な内容


## 参考URL
https://ja.stackoverflow.com/questions/3040/mitライセンスのソフトウェアをフォークした場合のライセンス表記
https://github.com/tcocca/acts_as_follower/blob/master/MIT-LICENSE

## キャプチャ
![warning](https://user-images.githubusercontent.com/26213141/70438875-20903f00-1ad2-11ea-932d-2ba2cd3a86a0.png)


