### PR TITLE
ゲーム画面のタイル等を中央に配置する

### DIFF
--- a/Assets/Project/Scripts/GamePlayScene/Bullet/NormalCartridgeController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/NormalCartridgeController.cs
@@ -69,9 +69,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
             // 移動方向に垂直な方向の初期座標
             var orthogonalMotionVector = motionVector.Transposition().Abs();
             var orthogonalMotionVectorPosition = new Vector2(TileSize.WIDTH * (line - 2),
-                WindowSize.HEIGHT * 0.5f -
-                (TileSize.MARGIN_TOP + TileSize.HEIGHT * 0.5f) -
-                TileSize.HEIGHT * (line - 1)) * orthogonalMotionVector;
+                TileSize.HEIGHT * (StageSize.ROW / 2 + 1 - line)) * orthogonalMotionVector;
             // 銃弾の座標の初期位置
             transform.position = motionVectorPosition + orthogonalMotionVectorPosition;
             // 銃弾画像の向きを反転させるかどうか

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/NormalCartridgeController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/NormalCartridgeController.cs
@@ -68,7 +68,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
                 -(WindowSize.HEIGHT + CartridgeSize.WIDTH * LOCAL_SCALE) / 2) * motionVector;
             // 移動方向に垂直な方向の初期座標
             var orthogonalMotionVector = motionVector.Transposition().Abs();
-            var orthogonalMotionVectorPosition = new Vector2(TileSize.WIDTH * (line - 2),
+            var orthogonalMotionVectorPosition = new Vector2(TileSize.WIDTH * (line - (StageSize.COLUMN / 2 + 1)),
                 TileSize.HEIGHT * (StageSize.ROW / 2 + 1 - line)) * orthogonalMotionVector;
             // 銃弾の座標の初期位置
             transform.position = motionVectorPosition + orthogonalMotionVectorPosition;

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/TurnCartridgeController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/TurnCartridgeController.cs
@@ -151,8 +151,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
                 // 警告の座標
                 _turnPoint[index] = cartridgePosition * cartridgeMotionVector.Transposition().Abs() + new Vector2(
                         TileSize.WIDTH * (turnLine[index] - 2),
-                        WindowSize.HEIGHT * 0.5f - (TileSize.MARGIN_TOP + TileSize.HEIGHT * 0.5f) -
-                        TileSize.HEIGHT * (turnLine[index] - 1)) * cartridgeMotionVector.Abs();
+                        TileSize.HEIGHT * (StageSize.ROW / 2 + 1 - turnLine[index])) * cartridgeMotionVector.Abs();
                 // 1フレームあたりの回転の角度
                 _turnAngle[index] = _turnDirection[index] % 2 == 1 ? 90 : -90;
                 _turnAngle[index] = (cartridgeMotionVector.x + cartridgeMotionVector.y) * _turnAngle[index];

--- a/Assets/Project/Scripts/GamePlayScene/Bullet/TurnCartridgeController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Bullet/TurnCartridgeController.cs
@@ -150,7 +150,7 @@ namespace Project.Scripts.GamePlayScene.Bullet
             for (var index = 0; index < turnDirection.Length; index++) {
                 // 警告の座標
                 _turnPoint[index] = cartridgePosition * cartridgeMotionVector.Transposition().Abs() + new Vector2(
-                        TileSize.WIDTH * (turnLine[index] - 2),
+                        TileSize.WIDTH * (turnLine[index] - (StageSize.COLUMN / 2 + 1)),
                         TileSize.HEIGHT * (StageSize.ROW / 2 + 1 - turnLine[index])) * cartridgeMotionVector.Abs();
                 // 1フレームあたりの回転の角度
                 _turnAngle[index] = _turnDirection[index] % 2 == 1 ? 90 : -90;

--- a/Assets/Project/Scripts/GamePlayScene/BulletWarning/CartridgeWarningController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/BulletWarning/CartridgeWarningController.cs
@@ -41,14 +41,12 @@ namespace Project.Scripts.GamePlayScene.BulletWarning
             switch (direction) {
                 case ECartridgeDirection.ToLeft:
                     warningPosition = new Vector2(WindowSize.WIDTH / 2,
-                        WindowSize.HEIGHT * 0.5f - (TileSize.MARGIN_TOP + TileSize.HEIGHT * 0.5f) -
-                        TileSize.HEIGHT * (line - 1));
+                        TileSize.HEIGHT * (StageSize.ROW / 2 + 1 - line));
                     bulletMotionVector = Vector2.left;
                     break;
                 case ECartridgeDirection.ToRight:
                     warningPosition = new Vector2(-WindowSize.WIDTH / 2,
-                        WindowSize.HEIGHT * 0.5f - (TileSize.MARGIN_TOP + TileSize.HEIGHT * 0.5f) -
-                        TileSize.HEIGHT * (line - 1));
+                        TileSize.HEIGHT * (StageSize.ROW / 2 + 1 - line));
                     bulletMotionVector = Vector2.right;
                     break;
                 case ECartridgeDirection.ToUp:

--- a/Assets/Project/Scripts/GamePlayScene/BulletWarning/CartridgeWarningController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/BulletWarning/CartridgeWarningController.cs
@@ -50,12 +50,12 @@ namespace Project.Scripts.GamePlayScene.BulletWarning
                     bulletMotionVector = Vector2.right;
                     break;
                 case ECartridgeDirection.ToUp:
-                    warningPosition = new Vector2(TileSize.WIDTH * (line - 2),
+                    warningPosition = new Vector2(TileSize.WIDTH * (line - (StageSize.COLUMN / 2 + 1)),
                         -WindowSize.HEIGHT / 2);
                     bulletMotionVector = Vector2.up;
                     break;
                 case ECartridgeDirection.ToBottom:
-                    warningPosition = new Vector2(TileSize.WIDTH * (line - 2),
+                    warningPosition = new Vector2(TileSize.WIDTH * (line - (StageSize.COLUMN / 2 + 1)),
                         WindowSize.HEIGHT / 2);
                     bulletMotionVector = Vector2.down;
                     break;

--- a/Assets/Project/Scripts/GamePlayScene/BulletWarning/NormalHoleWarningController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/BulletWarning/NormalHoleWarningController.cs
@@ -20,7 +20,7 @@ namespace Project.Scripts.GamePlayScene.BulletWarning
         public void Initialize(int row, int column)
         {
             transform.position =
-                new Vector2(TileSize.WIDTH * (column - 2), TileSize.HEIGHT * (StageSize.ROW / 2 + 1 - row));
+                new Vector2(TileSize.WIDTH * (column - ((StageSize.COLUMN / 2 + 1))), TileSize.HEIGHT * (StageSize.ROW / 2 + 1 - row));
         }
     }
 }

--- a/Assets/Project/Scripts/GamePlayScene/BulletWarning/NormalHoleWarningController.cs
+++ b/Assets/Project/Scripts/GamePlayScene/BulletWarning/NormalHoleWarningController.cs
@@ -19,9 +19,8 @@ namespace Project.Scripts.GamePlayScene.BulletWarning
         /// <param name="column"> 出現する列 </param>
         public void Initialize(int row, int column)
         {
-            const float topTilePositionY = WindowSize.HEIGHT * 0.5f - (TileSize.MARGIN_TOP + TileSize.HEIGHT * 0.5f);
             transform.position =
-                new Vector2(TileSize.WIDTH * (column - 2), topTilePositionY - TileSize.HEIGHT * (row - 1));
+                new Vector2(TileSize.WIDTH * (column - 2), TileSize.HEIGHT * (StageSize.ROW / 2 + 1 - row));
         }
     }
 }

--- a/Assets/Project/Scripts/GamePlayScene/Tile/TileGenerator.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Tile/TileGenerator.cs
@@ -102,7 +102,7 @@ namespace Project.Scripts.GamePlayScene.Tile
             // 列 (0~2)
             var column = tileNum % StageSize.COLUMN;
             // 作成するタイルのx,y座標
-            var positionX = TileSize.WIDTH * (column - 1);
+            var positionX = TileSize.WIDTH * (column - StageSize.COLUMN / 2);
             var positionY = TileSize.HEIGHT * (StageSize.ROW / 2 - row);
 
             return new Vector2(positionX, positionY);

--- a/Assets/Project/Scripts/GamePlayScene/Tile/TileGenerator.cs
+++ b/Assets/Project/Scripts/GamePlayScene/Tile/TileGenerator.cs
@@ -95,9 +95,6 @@ namespace Project.Scripts.GamePlayScene.Tile
         /// <returns></returns>
         private static Vector2 GetTilePosition(int tileNum)
         {
-            // 最上タイルのy座標
-            const float topTilePositionY = WindowSize.HEIGHT * 0.5f - (TileSize.MARGIN_TOP + TileSize.HEIGHT * 0.5f);
-
             // 処理計算では0から扱いたい
             tileNum -= 1;
             // 行 (0~4)
@@ -106,7 +103,7 @@ namespace Project.Scripts.GamePlayScene.Tile
             var column = tileNum % StageSize.COLUMN;
             // 作成するタイルのx,y座標
             var positionX = TileSize.WIDTH * (column - 1);
-            var positionY = topTilePositionY - TileSize.HEIGHT * row;
+            var positionY = TileSize.HEIGHT * (StageSize.ROW / 2 - row);
 
             return new Vector2(positionX, positionY);
         }

--- a/Assets/Project/Scripts/Utils/Definitions/SizeDefinitions.cs
+++ b/Assets/Project/Scripts/Utils/Definitions/SizeDefinitions.cs
@@ -16,9 +16,6 @@
     {
         public const float WIDTH = WindowSize.WIDTH * 0.22f;
         public const float HEIGHT = WIDTH;
-
-        // タイル群の上端位置を指定
-        public const float MARGIN_TOP = WindowSize.HEIGHT * 0.15f;
     }
 
     /// <summary>

--- a/Assets/Project/Scripts/Utils/Library/BulletLibrary.cs
+++ b/Assets/Project/Scripts/Utils/Library/BulletLibrary.cs
@@ -14,7 +14,7 @@ namespace Project.Scripts.Utils.Library
         public static(int, int) GetRowAndColumn(Vector2 position)
         {
             int row = (int)Math.Round(position.y / TileSize.HEIGHT, MidpointRounding.AwayFromZero) + StageSize.ROW / 2 + 1;
-            int column = (int)Math.Round((position.x / TileSize.WIDTH) + 1, MidpointRounding.AwayFromZero) + 1;
+            int column = (int)Math.Round(position.x / TileSize.WIDTH, MidpointRounding.AwayFromZero) + StageSize.COLUMN / 2 + 1;
             return (row, column);
         }
 

--- a/Assets/Project/Scripts/Utils/Library/BulletLibrary.cs
+++ b/Assets/Project/Scripts/Utils/Library/BulletLibrary.cs
@@ -13,9 +13,7 @@ namespace Project.Scripts.Utils.Library
         /// <param name="position"> 座標 </param>
         public static(int, int) GetRowAndColumn(Vector2 position)
         {
-            // 最上タイルのy座標
-            const float topTilePositionY = WindowSize.HEIGHT * 0.5f - (TileSize.MARGIN_TOP + TileSize.HEIGHT * 0.5f);
-            int row = (int)Math.Round((topTilePositionY - position.y) / TileSize.HEIGHT, MidpointRounding.AwayFromZero) + 1;
+            int row = (int)Math.Round(position.y / TileSize.HEIGHT, MidpointRounding.AwayFromZero) + StageSize.ROW / 2 + 1;
             int column = (int)Math.Round((position.x / TileSize.WIDTH) + 1, MidpointRounding.AwayFromZero) + 1;
             return (row, column);
         }


### PR DESCRIPTION
## 対象イシュー
Close #208

## 概要
- 若干中央より上に配置されているタイルを中央に配置しました。
- 伴って、銃弾の座標も変更しました。

## 技術的な内容
- タイルの行数(列数)が奇数ならば、中央及びその上下(左右)に配置するように記述しました。
偶数の場合には特に対応していません。

## キャプチャ
![scsho2](https://user-images.githubusercontent.com/26213141/71615383-671a1a80-2bf4-11ea-8a66-f1bbde0dfb58.png)


