### PR TITLE
PanelのinitPosをGUIで表示する

### DIFF
--- a/Assets/Project/Scripts/Editor/StageDataEditor.cs
+++ b/Assets/Project/Scripts/Editor/StageDataEditor.cs
@@ -76,6 +76,7 @@ public class StageDataEditor : Editor
             panelDataProp.isExpanded = EditorGUILayout.Foldout(panelDataProp.isExpanded, $"Panel {index + 1}");
             if (panelDataProp.isExpanded) {
                 EditorGUI.indentLevel++;
+                EditorGUILayout.PropertyField(panelDataProp.FindPropertyRelative("initPos"));
                 SerializedProperty panelTypeProp = panelDataProp.FindPropertyRelative("type");
                 panelTypeProp.enumValueIndex = (int)(EPanelType)EditorGUILayout.EnumPopup(new GUIContent("Type"), (EPanelType)panelTypeProp.enumValueIndex);
 


### PR DESCRIPTION
## 対象イシュー
Close #241

## 概要
- `PanelData`の`initPos`変数を`GUI`で表示する部分のコードを誤って消してしまっていた問題を修正した。

## 技術的な内容
特になし

## キャプチャ

