### PR TITLE
RandomCartridgeのline変数にRandomValueであることを示す値を代入する

### DIFF
--- a/Assets/Project/Scripts/Editor/StageDataEditor.cs
+++ b/Assets/Project/Scripts/Editor/StageDataEditor.cs
@@ -134,6 +134,8 @@ public class StageDataEditor : Editor
                                             includeObsolete: false
                                         );
 
+                                    if (lineProp.intValue == (int)ERow.Random) // 行(列)がランダムの場合強制に変える
+                                        lineProp.intValue = (int)ERow.First;
                                     switch ((ECartridgeDirection)directionProp.intValue) {
                                         case ECartridgeDirection.ToLeft:
                                         case ECartridgeDirection.ToRight:
@@ -156,6 +158,13 @@ public class StageDataEditor : Editor
                                             checkEnabled: (eType) => (ECartridgeDirection)eType == ECartridgeDirection.Random,
                                             includeObsolete: false
                                         );
+                                    lineProp.intValue = (int)(ERow.Random);
+                                    lineProp.intValue = (int)(ERow)EditorGUILayout.EnumPopup(
+                                            label: new GUIContent("Line"),
+                                            selected: (ERow)lineProp.intValue,
+                                            checkEnabled: (eType) => (ERow)eType == ERow.Random,
+                                            includeObsolete: false
+                                        );
                                     this.DrawFixedSizeArrayProperty(bulletDataProp.FindPropertyRelative("randomCartridgeDirection"), Enum.GetValues(typeof(ECartridgeDirection)).Length - 1);
                                     this.DrawFixedSizeArrayProperty(bulletDataProp.FindPropertyRelative("randomRow"), Enum.GetValues(typeof(ERow)).Length - 1);
                                     this.DrawFixedSizeArrayProperty(bulletDataProp.FindPropertyRelative("randomColumn"), Enum.GetValues(typeof(EColumn)).Length - 1);
@@ -174,6 +183,9 @@ public class StageDataEditor : Editor
                                             includeObsolete: false
                                         );
 
+                                    
+                                    if (lineProp.intValue == (int)ERow.Random) // 行(列)がランダムの場合強制に変える
+                                        lineProp.intValue = (int)ERow.First;
                                     switch ((ECartridgeDirection)directionProp.intValue) {
                                         case ECartridgeDirection.ToLeft:
                                         case ECartridgeDirection.ToRight:
@@ -198,6 +210,13 @@ public class StageDataEditor : Editor
                                             label: new GUIContent("Direction"),
                                             selected: (ECartridgeDirection)directionProp.intValue,
                                             checkEnabled: (eType) => (ECartridgeDirection)eType == ECartridgeDirection.Random,
+                                            includeObsolete: false
+                                        );
+                                    lineProp.intValue = (int)(ERow.Random);
+                                    lineProp.intValue = (int)(ERow)EditorGUILayout.EnumPopup(
+                                            label: new GUIContent("Line"),
+                                            selected: (ERow)lineProp.intValue,
+                                            checkEnabled: (eType) => (ERow)eType == ERow.Random,
                                             includeObsolete: false
                                         );
                                     this.DrawFixedSizeArrayProperty(bulletDataProp.FindPropertyRelative("randomCartridgeDirection"), Enum.GetValues(typeof(ECartridgeDirection)).Length - 1);

--- a/Assets/Project/Scripts/Editor/StageDataEditor.cs
+++ b/Assets/Project/Scripts/Editor/StageDataEditor.cs
@@ -175,14 +175,12 @@ public class StageDataEditor : Editor
                                     SerializedProperty lineProp = bulletDataProp.FindPropertyRelative("line");
                                     if (directionProp.intValue == (int)ECartridgeDirection.Random) // 方向がランダムの場合強制に変える
                                         directionProp.intValue = (int)ECartridgeDirection.ToLeft;
-
                                     directionProp.intValue = (int)(ECartridgeDirection)EditorGUILayout.EnumPopup(
                                             label: new GUIContent("Direction"),
                                             selected: (ECartridgeDirection)directionProp.intValue,
                                             checkEnabled: (eType) => (ECartridgeDirection)eType != ECartridgeDirection.Random,
                                             includeObsolete: false
                                         );
-
                                     
                                     if (lineProp.intValue == (int)ERow.Random) // 行(列)がランダムの場合強制に変える
                                         lineProp.intValue = (int)ERow.First;


### PR DESCRIPTION
## 対象イシュー
Close #243

## 概要
- `RandomNormalCartridge`及び`RandomTurnCartridge`の`line`変数に、`Row.Random(=-1)`を代入しました。
`BulletGenerator`内の処理で`Row.Random(=-1)`であるならば、具体的な`row`を決定するようにしているので、値が必要。
修正前では、`Random`な`Cartridge`を作成すると`line`変数はGUIに表示されなくなるので、直前の値が入っていた。

## 技術的な内容
特になし

## キャプチャ

